### PR TITLE
Define admin product interfaces and fix types

### DIFF
--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,0 +1,44 @@
+export interface ProductVariant {
+  id?: string | number;
+  size: string;
+  price: number;
+  stock: number;
+  refComplete?: string;
+  actif?: boolean;
+}
+
+export interface AdminProduct {
+  id: string | number;
+  codeArticle: string;
+  name: string;
+  nomParfumInspire: string;
+  marqueInspire: string;
+  brand: string;
+  price: number;
+  stock: number;
+  active: boolean;
+  imageURL: string;
+  genre: "homme" | "femme" | "mixte";
+  saison: "été" | "hiver" | "toutes saisons";
+  familleOlfactive: string;
+  noteTete?: string[];
+  noteCoeur?: string[];
+  noteFond?: string[];
+  description?: string;
+  lastModified?: number;
+  variants: ProductVariant[];
+}
+
+export interface EditFormData {
+  imageURL?: string;
+  codeArticle?: string;
+  name?: string;
+  nomParfumInspire?: string;
+  marqueInspire?: string;
+}
+
+export interface RestockSelection {
+  product: AdminProduct;
+  variant: ProductVariant;
+  variantIndex: number;
+}


### PR DESCRIPTION
## Summary
- define `AdminProduct`, `ProductVariant`, `EditFormData`, and `RestockSelection` interfaces
- use these interfaces in `AdminSpace.tsx`
- adjust state generics and data mapping
- cast IDs and genre/saison values as needed
- minor fixes to stock movement inserts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688189c929c4832b9003a91dfea419d0