### PR TITLE
Cleanup ping file and ignore lo folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ core
 
 .github/
 
+lo/

--- a/ping-vercel.txt
+++ b/ping-vercel.txt
@@ -1,1 +1,0 @@
-Déclenchement du déploiement


### PR DESCRIPTION
## Summary
- remove obsolete `ping-vercel.txt`
- ignore `lo/` directory so local Expo project doesn't appear in repo

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing packages like `react`)*

------
https://chatgpt.com/codex/tasks/task_e_688189d4ea78832bb86205abef56f1bd