### PR TITLE
Wrap new-product dialog in a form

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -3180,7 +3180,7 @@ const AdminSpace = () => {
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <form id="new-product-form" className="space-y-4">
+                    <form id="sales-report-form" className="space-y-4">
                       <div className="grid grid-cols-2 gap-4">
                         <div>
                           <Label>Date de début</Label>
@@ -3852,7 +3852,7 @@ const AdminSpace = () => {
               Ajouter un nouveau produit au catalogue
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
+          <form id="new-product-form" className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label>Code Article</Label>
@@ -4016,6 +4016,7 @@ const AdminSpace = () => {
             </div>
             <div className="flex gap-2">
               <Button
+                type="button"
                 variant="outline"
                 onClick={() => setShowNewProduct(false)}
                 className="flex-1"
@@ -4023,6 +4024,7 @@ const AdminSpace = () => {
                 Annuler
               </Button>
               <Button
+                type="button"
                 className="flex-1 bg-[#805050] hover:bg-[#704040] text-white"
                 onClick={async () => {
                   try {
@@ -4152,7 +4154,7 @@ const AdminSpace = () => {
                 Ajouter
               </Button>
             </div>
-          </div>
+          </form>
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Summary
- give the sales report filter its own `sales-report-form` id
- wrap the Nouveau Produit dialog fields in `new-product-form`
- ensure action buttons inside the dialog use `type="button"`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881b1fad434832ba155554de68ac7d6