### PR TITLE
Fix catalog query when active column missing

### DIFF
--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -54,15 +54,15 @@ const PerfumeCatalog = ({
       setLoading(true);
       console.log("🔄 Loading products directly from Supabase...");
 
-      const { data: productsData, error } = await supabase
-        .from("products")
-        .select(
-          `
-          *,
-          product_variants(*)
-        `,
-        )
-        .eq("active", true); // Only active products
+        const { data: productsData, error } = await supabase
+          .from("products")
+          .select(
+            `
+            *,
+            product_variants(*)
+          `,
+          );
+        // Some deployments may lack the `active` column; avoid filtering by it
 
       if (error) {
         console.error("Error loading products from Supabase:", error);


### PR DESCRIPTION
## Summary
- remove `eq("active", true)` filter in catalog query

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886a9b95720832b8f0920aa11c6643b