### PR TITLE
feat: allow including inactive perfumes

### DIFF
--- a/src/components/catalog/PerfumeCard.tsx
+++ b/src/components/catalog/PerfumeCard.tsx
@@ -15,6 +15,7 @@ interface PerfumeCardProps {
   genre?: "homme" | "femme" | "mixte";
   saison?: "été" | "hiver" | "toutes saisons";
   familleOlfactive?: string;
+  active?: boolean;
   onClick?: () => void;
 }
 
@@ -27,6 +28,7 @@ const PerfumeCard = ({
   genre = "femme",
   saison = "toutes saisons",
   familleOlfactive = "Oriental Vanillé",
+  active = true,
   onClick = () => {},
 }: PerfumeCardProps) => {
   const { addToFavorites, removeFromFavorites, isFavorite } = useFavorites();
@@ -82,7 +84,9 @@ const PerfumeCard = ({
 
   return (
     <Card
-      className="w-full max-w-[280px] overflow-hidden transition-all duration-300 hover:shadow-lg cursor-pointer bg-white"
+      className={`w-full max-w-[280px] overflow-hidden transition-all duration-300 hover:shadow-lg cursor-pointer bg-white ${
+        !active ? "opacity-50" : ""
+      }`}
       onClick={onClick}
     >
       <div className="relative h-[200px] overflow-hidden">


### PR DESCRIPTION
## Summary
- add `includeInactive` option and track `active` flag in catalog perfumes
- query Supabase conditionally for active products and filter visible list
- forward active status to `PerfumeCard`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_689b10187c1c832ba99251bcd2d22809