### PR TITLE
Include inactive products in admin catalog and emit status updates

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -607,6 +607,10 @@ const AdminSpace = () => {
         prev.map((p) => (p.id === productId ? { ...p, active: !p.active } : p)),
       );
 
+      window.dispatchEvent(
+        new CustomEvent("productStatusUpdated", { detail: { id: productId } }),
+      );
+
       alert("Statut du produit mis à jour avec succès!");
     } catch (error) {
       console.error("Error toggling product status:", error);
@@ -3645,6 +3649,7 @@ const AdminSpace = () => {
                     </div>
                   </div>
                   <PerfumeCatalog
+                    includeInactive
                     key={`catalog-${products.length}-${Date.now()}`}
                     onPerfumeSelect={(perfume) => {
                       // Find the actual product from our products array


### PR DESCRIPTION
## Summary
- Show inactive products in admin catalog view
- Emit `productStatusUpdated` event after toggling product status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689b1484a600832b97e61938d1577d57