### PR TITLE
feat: allow admin to open inactive perfumes

### DIFF
--- a/src/components/catalog/PerfumeCard.tsx
+++ b/src/components/catalog/PerfumeCard.tsx
@@ -17,6 +17,11 @@ interface PerfumeCardProps {
   familleOlfactive?: string;
   active?: boolean;
   onClick?: () => void;
+  /**
+   * Allow clicking on inactive products. Useful in admin views where
+   * details of inactive items should remain accessible.
+   */
+  allowInactiveClick?: boolean;
 }
 
 const PerfumeCard = ({
@@ -30,6 +35,7 @@ const PerfumeCard = ({
   familleOlfactive = "Oriental Vanillé",
   active = true,
   onClick = () => {},
+  allowInactiveClick = false,
 }: PerfumeCardProps) => {
   const { addToFavorites, removeFromFavorites, isFavorite } = useFavorites();
   const { isAuthenticated } = useAuth();
@@ -86,7 +92,9 @@ const PerfumeCard = ({
     <div className="relative">
       <Card
         className={`w-full max-w-[280px] overflow-hidden transition-all duration-300 hover:shadow-lg cursor-pointer bg-white ${
-          !active ? "opacity-50 grayscale pointer-events-none" : ""
+          !active
+            ? `opacity-50 grayscale${allowInactiveClick ? "" : " pointer-events-none"}`
+            : ""
         }`}
         onClick={onClick}
       >
@@ -146,7 +154,7 @@ const PerfumeCard = ({
       </CardContent>
     </Card>
     {!active && (
-      <div className="absolute inset-0 backdrop-blur-sm flex items-center justify-center text-red-600 font-bold text-sm">
+      <div className="pointer-events-none absolute inset-0 backdrop-blur-sm flex items-center justify-center text-red-600 font-bold text-sm">
         Produit inactif
       </div>
     )}

--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -430,6 +430,7 @@ const PerfumeCatalog = ({
               saison={perfume.saison}
               familleOlfactive={perfume.familleOlfactive}
               active={perfume.active}
+              allowInactiveClick={includeInactive}
               onClick={() => onPerfumeSelect(perfume)}
             />
           ))


### PR DESCRIPTION
## Summary
- keep admin catalog showing inactive products
- allow inactive perfume cards to be clicked when viewing as admin

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config)
- `npm run build` (fails: Property 'codeArticle' does not exist on type '{}')

------
https://chatgpt.com/codex/tasks/task_e_689b16c45598832b81fd9f29cc422113