### PR TITLE
style: add subtle blur to inactive PerfumeCard

### DIFF
--- a/src/components/catalog/PerfumeCard.tsx
+++ b/src/components/catalog/PerfumeCard.tsx
@@ -93,7 +93,7 @@ const PerfumeCard = ({
       <Card
         className={`w-full max-w-[280px] overflow-hidden transition-all duration-300 hover:shadow-lg cursor-pointer bg-white ${
           !active
-            ? `opacity-50 grayscale${allowInactiveClick ? "" : " pointer-events-none"}`
+            ? `grayscale filter blur-[1px]${allowInactiveClick ? "" : " pointer-events-none"}`
             : ""
         }`}
         onClick={onClick}
@@ -154,7 +154,7 @@ const PerfumeCard = ({
       </CardContent>
     </Card>
     {!active && (
-      <div className="pointer-events-none absolute inset-0 backdrop-blur-sm flex items-center justify-center text-red-600 font-bold text-sm">
+      <div className="pointer-events-none absolute inset-0 backdrop-blur-[1px] flex items-center justify-center text-red-600 font-bold text-sm">
         Produit inactif
       </div>
     )}


### PR DESCRIPTION
## Summary
- add light blur to inactive PerfumeCard images
- reduce overlay blur for inactive product notice

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find eslint.config.js)
- `npm run build` (TS errors during build)


------
https://chatgpt.com/codex/tasks/task_e_689b1958993c832b84f4ee5253a98cb4