### PR TITLE
chore: automate Supabase migrations via GitHub Actions

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,21 @@
+name: Supabase Migrations
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Link project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      - name: Apply migrations
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/docs/DB_MIGRATIONS.md
+++ b/docs/DB_MIGRATIONS.md
@@ -1,0 +1,25 @@
+# Migrations Supabase — Mode d’emploi
+
+## Secrets à ajouter dans GitHub (Repo → Settings → Secrets and variables → Actions)
+- SUPABASE_ACCESS_TOKEN : créer dans Supabase (Profile → Access Tokens)
+- SUPABASE_PROJECT_REF  : identifiant du projet (ex: hxuioxxxxxx, visible dans l’URL ou Settings → General)
+
+> Après ajout des secrets, faites un petit commit (ex: modif README) pour déclencher l’action.
+
+## Ajouter une migration
+1. Créer un fichier dans `supabase/migrations/` nommé `YYYYMMDD_HHMM_description.sql`.
+2. Écrire du SQL **idempotent** :
+   - `create table if not exists ...`
+   - `alter table if exists ... add column if not exists ...`
+   - Policies RLS : `drop policy if exists ...` puis `create policy ...`
+3. Push sur `main` → la GitHub Action applique automatiquement sur Supabase.
+
+## Vérifier
+- GitHub → Actions → **Supabase Migrations** doit être en vert.
+- Supabase → Table Editor : la table `_migrations_healthcheck` (ou votre changement) existe.
+
+## Bonnes pratiques
+- Ne modifiez pas le schéma dans l’UI Supabase **sans** créer la migration correspondante.
+- Ne jamais committer de clés sensibles. Le Front n’utilise que :
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`

--- a/supabase/migrations/20250812_0001_healthcheck.sql
+++ b/supabase/migrations/20250812_0001_healthcheck.sql
@@ -1,0 +1,7 @@
+-- Healthcheck idempotent pour valider le pipeline CI
+create table if not exists public._migrations_healthcheck (
+  id bigint generated always as identity primary key,
+  created_at timestamptz default now()
+);
+
+comment on table public._migrations_healthcheck is 'Table de vérification du pipeline de migrations CI';


### PR DESCRIPTION
## Summary
- automate Supabase migrations on push to `main`
- add idempotent healthcheck migration
- document how to manage Supabase migrations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_689b30fac718832bb81784bd52c2b907