### PR TITLE
chore: ensure idempotent user policy migration

### DIFF
--- a/supabase/migrations/20250120000002_fix_auth_issues.sql
+++ b/supabase/migrations/20250120000002_fix_auth_issues.sql
@@ -72,6 +72,7 @@ ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS "Users can view own profile" ON public.users;
 DROP POLICY IF EXISTS "Users can update own profile" ON public.users;
 DROP POLICY IF EXISTS "Enable insert for authenticated users only" ON public.users;
+DROP POLICY IF EXISTS "Service role can manage all users" ON public.users;
 
 -- Create policies for users table
 CREATE POLICY "Users can view own profile" ON public.users


### PR DESCRIPTION
## Summary
- Drop existing service role policy before re-creating it in auth fix migration to make reruns safe

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689b63168830832ba3e2c95f6e837cfc