### PR TITLE
Remove bold styling from admin space heading

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -2555,7 +2555,7 @@ const AdminSpace = () => {
         >
           <div className="flex justify-between items-center mb-8">
             <div className="text-center flex-1">
-              <h2 className="text-3xl font-bold font-playfair text-[#805050] mb-4">
+              <h2 className="text-3xl font-normal font-playfair text-[#805050] mb-4">
                 Espace Administration
               </h2>
               <p className="text-[#AD9C92] font-montserrat">


### PR DESCRIPTION
## Summary
- make admin dashboard "Espace Administration" heading non-bold

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)
- `npm run build` (reports TS errors but completes build)


------
https://chatgpt.com/codex/tasks/task_e_689d2fcf50a0832ba55bed2e6853b4e6