### PR TITLE
feat(db): add origin country to products

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -178,6 +178,7 @@ export type Database = {
           genre: string
           id: string
           image_url: string | null
+          origin_country: string | null
           marque_inspire: string
           nom_lolly: string
           nom_parfum_inspire: string
@@ -203,6 +204,7 @@ export type Database = {
           genre: string
           id?: string
           image_url?: string | null
+          origin_country?: string | null
           marque_inspire: string
           nom_lolly: string
           nom_parfum_inspire: string
@@ -228,6 +230,7 @@ export type Database = {
           genre?: string
           id?: string
           image_url?: string | null
+          origin_country?: string | null
           marque_inspire?: string
           nom_lolly?: string
           nom_parfum_inspire?: string

--- a/supabase/migrations/20250813000001_add_origin_country_to_products.sql
+++ b/supabase/migrations/20250813000001_add_origin_country_to_products.sql
@@ -1,0 +1,5 @@
+-- Adds origin_country column to products table
+ALTER TABLE public.products
+ADD COLUMN IF NOT EXISTS origin_country TEXT;
+
+COMMENT ON COLUMN public.products.origin_country IS 'Pays d\'origine du produit';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS public.products (
     famille_olfactive TEXT,
     description TEXT,
     image_url TEXT,
+    origin_country TEXT,
     created_at TIMESTAMP DEFAULT NOW()
 );
 


### PR DESCRIPTION
## Summary
- add migration to introduce origin_country column
- include origin_country in schema and generated supabase types

## Testing
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)


------
https://chatgpt.com/codex/tasks/task_e_689d43786e7c832b9797be1f1c119817