### PR TITLE
Add country code column to customers

### DIFF
--- a/supabase/migrations/20250814000000_add_country_code_to_customers.sql
+++ b/supabase/migrations/20250814000000_add_country_code_to_customers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS public.customers
+ADD COLUMN IF NOT EXISTS country_code TEXT;


### PR DESCRIPTION
## Summary
- add migration to include `country_code` text field on `customers`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689d531b9f28832b86d5dec095894021