### PR TITLE
chore: drop audit table and redundant index

### DIFF
--- a/supabase/migrations/20250814000000_drop_ddl_audit_and_idx_variants_ref_complete.sql
+++ b/supabase/migrations/20250814000000_drop_ddl_audit_and_idx_variants_ref_complete.sql
@@ -1,0 +1,5 @@
+-- Suppression des éléments inutiles
+DROP TABLE IF EXISTS public.ddl_audit;
+
+-- La contrainte product_variants_ref_complete_key assure déjà l'unicité
+DROP INDEX IF EXISTS public.idx_variants_ref_complete;


### PR DESCRIPTION
## Summary
- drop unused `ddl_audit` table if present
- remove redundant `idx_variants_ref_complete` index

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file.)

------
https://chatgpt.com/codex/tasks/task_e_689e52878104832b9090139242225a93