### PR TITLE
fix: allow custom client code on register

### DIFF
--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -130,9 +130,15 @@ export async function register(
   },
 ): Promise<User | null> {
   try {
-    const { password, role = "client" } = userData;
-    const rolePrefix = role === "conseillere" ? "CNS" : role === "admin" ? "ADM" : "C";
-    const codeClient = `${rolePrefix}${Date.now().toString().slice(-3)}`;
+    const {
+      password,
+      role = "client",
+      codeClient: providedCodeClient,
+    } = userData;
+    const rolePrefix =
+      role === "conseillere" ? "CNS" : role === "admin" ? "ADM" : "C";
+    const codeClient =
+      providedCodeClient || `${rolePrefix}${Date.now().toString().slice(-3)}`;
 
     const { data: authData, error: authError } = await supabase.auth.signUp({
       email: userData.email,
@@ -178,7 +184,7 @@ export async function register(
       dateNaissance: userData.dateNaissance,
       adresse: userData.adresse,
       role,
-      codeClient,
+      codeClient: insertedUser.code_client || codeClient,
     };
   } catch (err) {
     logger.error("Unexpected registration error", err);


### PR DESCRIPTION
## Summary
- allow providing a custom `codeClient` on registration
- return database `code_client` value after user creation

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `node test-register.cjs` *(fails: fetch failed / ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689e61c9c0a0832badb79dc9455d7a08