### PR TITLE
Wrap App in BrowserRouter

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 // ⚠️ Très important: import du CSS global (Tailwind, etc.)
@@ -7,6 +8,8 @@ import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- enable React Router by wrapping `App` with `BrowserRouter`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(errors: TypeScript property and chunk size warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e96c9753c832bb4cc17fdd32f0e49