### PR TITLE
Close login dialog after registration

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -107,6 +107,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({
         setRegMsg(
           "Inscription créée. Vérifie ta boîte mail pour confirmer l'adresse."
         );
+        onOpenChange(false);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Close login dialog and show confirmation message when registration requires email confirmation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(warning: Empty routes array generated)*

------
https://chatgpt.com/codex/tasks/task_e_689e9acc7b80832b8250e8dc0247e970