### PR TITLE
feat: exchange auth code for session

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -24,6 +24,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code') ?? params.get('token');
+    if (code) {
+      supabase.auth.exchangeCodeForSession(code).then(({ data }) => {
+        if (data?.session) {
+          setSession(data.session);
+          setUser(data.session.user);
+          window.history.replaceState({}, '', window.location.pathname);
+        }
+      });
+    }
+
     let mounted = true;
 
     (async () => {


### PR DESCRIPTION
## Summary
- exchange auth code for session to auto login and clean URL during auth initialization

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: Property errors in TypeScript files)*


------
https://chatgpt.com/codex/tasks/task_e_689e9d9e6c1c832b9795d752c39be823