### PR TITLE
Remove redirect to /client from Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,14 +5,6 @@
   "installCommand": "npm install",
   "framework": "vite",
 
-  "redirects": [
-    {
-      "source": "/",
-      "destination": "/client",
-      "permanent": true
-    }
-  ],
-
   "rewrites": [
     {
       "source": "/((?!api/).+)",


### PR DESCRIPTION
## Summary
- remove `/client` redirect from Vercel config so root stays on `/`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build`
- `npx vercel --prod` *(fails: 403 Forbidden fetching vercel package)*

------
https://chatgpt.com/codex/tasks/task_e_689ea4d2dc8c832b9bd0c820a421cc9c