### PR TITLE
feat(auth): clarify unconfirmed email login error

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -43,7 +43,11 @@ const LoginDialog: React.FC<LoginDialogProps> = ({
 
     setLoginBusy(false);
     if (!res.ok) {
-      setLoginMsg(`Connexion refusée (${res.step}) : ${res.error}`);
+      if (res.error === 'Email non confirmée. Vérifiez votre boîte de réception.') {
+        setLoginMsg(res.error);
+      } else {
+        setLoginMsg(`Connexion refusée (${res.step}) : ${res.error}`);
+      }
       return;
     }
     setLoginMsg("Connecté ✅");

--- a/src/features/auth/signIn.ts
+++ b/src/features/auth/signIn.ts
@@ -9,7 +9,16 @@ import { supabase } from '../../lib/supabaseClient';
 export async function handleSignIn(email: string, password: string) {
   // 1) Auth email/mot de passe
   const { data, error } = await supabase.auth.signInWithPassword({ email, password });
-  if (error) return { ok: false, step: 'auth', error: error.message };
+  if (error) {
+    if (error.message?.includes('Email not confirmed')) {
+      return {
+        ok: false,
+        step: 'auth',
+        error: 'Email non confirmée. Vérifiez votre boîte de réception.',
+      };
+    }
+    return { ok: false, step: 'auth', error: error.message };
+  }
 
   const { user } = data;
 


### PR DESCRIPTION
## Summary
- handle unconfirmed email error explicitly in sign-in
- surface unconfirmed email message directly in login dialog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689eaebcb188832bb4b1f189637b45b9