### PR TITLE
Persist cart orders to Supabase and live refresh admin sales

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -375,6 +375,14 @@ const AdminSpace = () => {
     };
   }, []);
 
+  useEffect(() => {
+    const handleNewSale = (e) =>
+      setOrders((prev) => [e.detail, ...prev]);
+    window.addEventListener("newSaleRecorded", handleNewSale);
+    return () =>
+      window.removeEventListener("newSaleRecorded", handleNewSale);
+  }, []);
+
   const handleExportExcel = (type) => {
     // Create CSV content with UTF-8 BOM for Excel compatibility
     let csvContent = "\uFEFF"; // UTF-8 BOM


### PR DESCRIPTION
## Summary
- save finalized cart orders to Supabase `orders` table
- auto-refresh AdminSpace sales list on `newSaleRecorded` events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: TS2339 properties missing on type 'User')*

------
https://chatgpt.com/codex/tasks/task_e_689eb19d1ffc832b983a85faf69594f2