### PR TITLE
feat: add orders and order_items tables with RLS

### DIFF
--- a/supabase/migrations/20250814000000_add_orders_and_order_items_policies.sql
+++ b/supabase/migrations/20250814000000_add_orders_and_order_items_policies.sql
@@ -1,0 +1,38 @@
+-- Create orders and order_items tables with RLS policies
+
+-- Tables (if not already created)
+create table if not exists public.orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.users(id),
+  code_client text not null,
+  total_amount numeric not null,
+  status text not null default 'en_attente' check (status in ('en_attente','confirmee','expediee','livree','annulee')),
+  conseillere_id uuid references public.users(id),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.order_items (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid references public.orders(id) on delete cascade,
+  product_variant_id uuid references public.product_variants(id),
+  quantity integer not null,
+  unit_price numeric not null,
+  total_price numeric not null,
+  created_at timestamptz default now()
+);
+
+-- Row Level Security policies
+alter table public.orders enable row level security;
+create policy "Users insert own orders"
+  on public.orders for insert with check (auth.uid() = user_id);
+create policy "Users read own orders"
+  on public.orders for select using (auth.uid() = user_id);
+
+alter table public.order_items enable row level security;
+create policy "Insert items for own orders"
+  on public.order_items for insert
+  with check (exists (select 1 from orders where id = order_id and user_id = auth.uid()));
+create policy "Read items for own orders"
+  on public.order_items for select
+  using (exists (select 1 from orders where id = order_id and user_id = auth.uid()));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -39,10 +39,34 @@ CREATE TABLE IF NOT EXISTS public.product_variants (
 CREATE TABLE IF NOT EXISTS public.orders (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid REFERENCES public.users(id),
-    code_client TEXT,
+    code_client TEXT NOT NULL,
     total_amount NUMERIC NOT NULL,
     status TEXT NOT NULL DEFAULT 'en_attente' CHECK (status IN ('en_attente', 'confirmee', 'expediee', 'livree', 'annulee')),
-    conseillere_id uuid,
+    conseillere_id uuid REFERENCES public.users(id),
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS public.order_items (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id uuid REFERENCES public.orders(id) ON DELETE CASCADE,
+    product_variant_id uuid REFERENCES public.product_variants(id),
+    quantity INTEGER NOT NULL,
+    unit_price NUMERIC NOT NULL,
+    total_price NUMERIC NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users insert own orders"
+    ON public.orders FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users read own orders"
+    ON public.orders FOR SELECT USING (auth.uid() = user_id);
+
+ALTER TABLE public.order_items ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Insert items for own orders"
+    ON public.order_items FOR INSERT
+    WITH CHECK (EXISTS (SELECT 1 FROM orders WHERE id = order_id AND user_id = auth.uid()));
+CREATE POLICY "Read items for own orders"
+    ON public.order_items FOR SELECT
+    USING (EXISTS (SELECT 1 FROM orders WHERE id = order_id AND user_id = auth.uid()));


### PR DESCRIPTION
## Summary
- add migration defining orders and order_items tables with row-level security policies
- update schema.sql to include new tables and policies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689eb695a700832b8757038547b8489e