### PR TITLE
Emit item-level sale events with identifiers

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -376,8 +376,28 @@ const AdminSpace = () => {
   }, []);
 
   useEffect(() => {
-    const handleNewSale = (e) =>
-      setOrders((prev) => [e.detail, ...prev]);
+    const handleNewSale = (e: any) => {
+      // If the event contains a products array, expand each item into its own entry
+      if (Array.isArray(e.detail?.products)) {
+        const entries = e.detail.products.map((p: any, index: number) => ({
+          id: `${Date.now()}-${index}-${p.codeArticle}`,
+          date: e.detail.date,
+          client: e.detail.client,
+          codeClient: e.detail.codeClient,
+          product: p.product,
+          codeArticle: p.codeArticle,
+          amount: p.amount,
+          conseillere: p.conseillere || "N/A",
+        }));
+        setOrders((prev) => [...entries, ...prev]);
+      } else {
+        const sale = {
+          ...e.detail,
+          id: e.detail?.id ?? `${Date.now()}`,
+        };
+        setOrders((prev) => [sale, ...prev]);
+      }
+    };
     window.addEventListener("newSaleRecorded", handleNewSale);
     return () =>
       window.removeEventListener("newSaleRecorded", handleNewSale);

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -119,17 +119,22 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       existingOrders.unshift(orderData);
       localStorage.setItem("client-orders", JSON.stringify(existingOrders));
 
-      // 5. Notify admin space with full order details
-      const adminEvent = new CustomEvent("newSaleRecorded", {
-        detail: {
-          date: orderData.date,
-          client: orderData.client,
-          codeClient: orderData.codeClient,
-          totalAmount: orderData.totalAmount,
-          products: orderData.items,
-        },
+      // 5. Notify admin space for each item with expected keys
+      orderData.items.forEach((item: any) => {
+        const adminEvent = new CustomEvent("newSaleRecorded", {
+          detail: {
+            id: `${orderId}-${item.codeArticle}`,
+            date: orderData.date,
+            client: orderData.client,
+            codeClient: orderData.codeClient,
+            product: item.product,
+            codeArticle: item.codeArticle,
+            amount: item.amount,
+            conseillere: "N/A",
+          },
+        });
+        window.dispatchEvent(adminEvent);
       });
-      window.dispatchEvent(adminEvent);
 
       // Process order
       setOrderComplete(true);


### PR DESCRIPTION
## Summary
- emit `newSaleRecorded` per cart item with product details and id
- expand admin handler to normalize events and guarantee ids

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689ebb52d9e4832ba9a809ffdeaec90d