### PR TITLE
feat: unify variant references with ml suffix and validate cart items

### DIFF
--- a/src/components/ClientSpace.tsx
+++ b/src/components/ClientSpace.tsx
@@ -227,7 +227,7 @@ const ClientSpace = () => {
       imageURL: perfume.imageURL,
       contenances: [
         {
-          refComplete: `${perfume.codeProduit}-15`,
+          refComplete: `${perfume.codeProduit}-15ml`,
           contenance: 15,
           unite: "ml",
           prix: 19.9,
@@ -235,7 +235,7 @@ const ClientSpace = () => {
           actif: true,
         },
         {
-          refComplete: `${perfume.codeProduit}-30`,
+          refComplete: `${perfume.codeProduit}-30ml`,
           contenance: 30,
           unite: "ml",
           prix: 29.9,
@@ -243,7 +243,7 @@ const ClientSpace = () => {
           actif: true,
         },
         {
-          refComplete: `${perfume.codeProduit}-50`,
+          refComplete: `${perfume.codeProduit}-50ml`,
           contenance: 50,
           unite: "ml",
           prix: 39.9,
@@ -425,7 +425,7 @@ const ClientSpace = () => {
                                 "Une fragrance élégante et raffinée.",
                               contenances: [
                                 {
-                                  refComplete: `${favorite.codeProduit}-15`,
+                                  refComplete: `${favorite.codeProduit}-15ml`,
                                   contenance: 15,
                                   unite: "ml",
                                   prix: 19.9,
@@ -433,7 +433,7 @@ const ClientSpace = () => {
                                   actif: true,
                                 },
                                 {
-                                  refComplete: `${favorite.codeProduit}-30`,
+                                  refComplete: `${favorite.codeProduit}-30ml`,
                                   contenance: 30,
                                   unite: "ml",
                                   prix: 29.9,
@@ -441,7 +441,7 @@ const ClientSpace = () => {
                                   actif: true,
                                 },
                                 {
-                                  refComplete: `${favorite.codeProduit}-50`,
+                                  refComplete: `${favorite.codeProduit}-50ml`,
                                   contenance: 50,
                                   unite: "ml",
                                   prix: 39.9,
@@ -721,7 +721,7 @@ const ClientSpace = () => {
                                     "Une fragrance élégante et raffinée.",
                                   contenances: [
                                     {
-                                      refComplete: `${favorite.codeProduit}-15`,
+                                      refComplete: `${favorite.codeProduit}-15ml`,
                                       contenance: 15,
                                       unite: "ml",
                                       prix: 19.9,
@@ -729,7 +729,7 @@ const ClientSpace = () => {
                                       actif: true,
                                     },
                                     {
-                                      refComplete: `${favorite.codeProduit}-30`,
+                                      refComplete: `${favorite.codeProduit}-30ml`,
                                       contenance: 30,
                                       unite: "ml",
                                       prix: 29.9,
@@ -737,7 +737,7 @@ const ClientSpace = () => {
                                       actif: true,
                                     },
                                     {
-                                      refComplete: `${favorite.codeProduit}-50`,
+                                      refComplete: `${favorite.codeProduit}-50ml`,
                                       contenance: 50,
                                       unite: "ml",
                                       prix: 39.9,

--- a/src/components/ConseillerSpace.tsx
+++ b/src/components/ConseillerSpace.tsx
@@ -215,7 +215,7 @@ const ConseillerSpace = () => {
       imageURL: perfume.imageURL,
       contenances: [
         {
-          refComplete: `${perfume.codeProduit}-15`,
+          refComplete: `${perfume.codeProduit}-15ml`,
           contenance: 15,
           unite: "ml",
           prix: 19.9,
@@ -223,7 +223,7 @@ const ConseillerSpace = () => {
           actif: true,
         },
         {
-          refComplete: `${perfume.codeProduit}-30`,
+          refComplete: `${perfume.codeProduit}-30ml`,
           contenance: 30,
           unite: "ml",
           prix: 29.9,
@@ -231,7 +231,7 @@ const ConseillerSpace = () => {
           actif: true,
         },
         {
-          refComplete: `${perfume.codeProduit}-50`,
+          refComplete: `${perfume.codeProduit}-50ml`,
           contenance: 50,
           unite: "ml",
           prix: 39.9,

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -85,13 +85,22 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       );
 
       // 3. Insert order items
-      const orderItems = items.map((item) => ({
-        order_id: orderId,
-        product_variant_id: variantMap.get(item.refComplete),
-        quantity: item.quantity,
-        unit_price: item.prix,
-        total_price: item.prix * item.quantity,
-      }));
+      const orderItems = [] as any[];
+      for (const item of items) {
+        const variantId = variantMap.get(item.refComplete);
+        if (!variantId) {
+          alert("Référence produit introuvable");
+          setIsSubmitting(false);
+          return;
+        }
+        orderItems.push({
+          order_id: orderId,
+          product_variant_id: variantId,
+          quantity: item.quantity,
+          unit_price: item.prix,
+          total_price: item.prix * item.quantity,
+        });
+      }
       const { error: itemsError } = await supabase
         .from("order_items")
         .insert(orderItems);

--- a/src/components/catalog/PerfumeDetail.tsx
+++ b/src/components/catalog/PerfumeDetail.tsx
@@ -70,7 +70,7 @@ const PerfumeDetail: React.FC<PerfumeDetailProps> = ({
         "https://images.unsplash.com/photo-1594035910387-fea47794261f?w=500&q=80",
       contenances: [
         {
-          refComplete: "L001-15",
+          refComplete: "L001-15ml",
           contenance: 15,
           unite: "ml",
           prix: 19.9,
@@ -78,7 +78,7 @@ const PerfumeDetail: React.FC<PerfumeDetailProps> = ({
           actif: true,
         },
         {
-          refComplete: "L001-30",
+          refComplete: "L001-30ml",
           contenance: 30,
           unite: "ml",
           prix: 29.9,
@@ -86,7 +86,7 @@ const PerfumeDetail: React.FC<PerfumeDetailProps> = ({
           actif: true,
         },
         {
-          refComplete: "L001-50",
+          refComplete: "L001-50ml",
           contenance: 50,
           unite: "ml",
           prix: 39.9,
@@ -94,7 +94,7 @@ const PerfumeDetail: React.FC<PerfumeDetailProps> = ({
           actif: true,
         },
         {
-          refComplete: "L001-100",
+          refComplete: "L001-100ml",
           contenance: 100,
           unite: "ml",
           prix: 59.9,


### PR DESCRIPTION
## Summary
- append `ml` suffix to variant reference codes across client and conseiller flows
- ensure cart additions use `-15ml`, `-30ml` and `-50ml` format
- warn on checkout when product reference is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689ebfd5edbc832b9e2279cde5c23c14