### PR TITLE
Remove ml suffix from variant references

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -4317,7 +4317,7 @@ const AdminSpace = () => {
                     for (const variant of variants) {
                       await supabase.from("product_variants").insert({
                         product_id: newProduct.id,
-                        ref_complete: `${newProduct.code_produit}-${variant.size}`,
+                        ref_complete: `${newProduct.code_produit}-${parseInt(variant.size)}`,
                         contenance: parseInt(variant.size),
                         unite: "ml",
                         prix: variant.price,

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -74,7 +74,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       const orderId = newOrder.id;
 
       // 2. Fetch product variant ids for items in cart
-      const refs = items.map((item) => item.refComplete.replace(/ml$/, ""));
+      const refs = items.map((item) => item.refComplete);
       const { data: variants, error: variantError } = await supabase
         .from("product_variants")
         .select("id, ref_complete, stock_actuel")
@@ -82,7 +82,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       if (variantError) throw variantError;
       const variantMap = new Map(
         variants.map((v: any) => [
-          v.ref_complete.replace(/ml$/, ""),
+          v.ref_complete,
           { id: v.id, stock_actuel: v.stock_actuel },
         ]),
       );
@@ -90,9 +90,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       // 3. Insert order items
       const orderItems = [] as any[];
       for (const item of items) {
-        const variant = variantMap.get(
-          item.refComplete.replace(/ml$/, ""),
-        );
+        const variant = variantMap.get(item.refComplete);
         if (!variant) {
           alert("Référence produit introuvable");
           setIsSubmitting(false);
@@ -116,9 +114,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       const movementIds: string[] = [];
       try {
         for (const item of items) {
-          const variant = variantMap.get(
-            item.refComplete.replace(/ml$/, ""),
-          );
+          const variant = variantMap.get(item.refComplete);
           if (!variant) continue;
           const previousStock = variant.stock_actuel || 0;
           const newStock = previousStock - item.quantity;

--- a/supabase/migrations/20250901000000_remove_ml_suffix_from_ref_complete.sql
+++ b/supabase/migrations/20250901000000_remove_ml_suffix_from_ref_complete.sql
@@ -1,0 +1,5 @@
+-- Remove trailing 'ml' from ref_complete values
+UPDATE product_variants
+SET ref_complete = regexp_replace(ref_complete, 'ml$', '')
+WHERE ref_complete LIKE '%ml';
+


### PR DESCRIPTION
## Summary
- store numeric ref_complete when creating product variants
- migrate existing variant refs to remove trailing `ml`
- query product variants by refComplete directly in cart dialog

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(passes with warnings: Property 'telephone' does not exist on type 'User'...)*

------
https://chatgpt.com/codex/tasks/task_e_689f71d8c804832ba64c0101b337bf3e