### PR TITLE
Handle errors when fetching session

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -52,11 +52,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     let mounted = true;
 
     (async () => {
-      const { data } = await supabase.auth.getSession();
-      if (!mounted) return;
-      setSession(data.session ?? null);
-      setUser(data.session?.user ?? null);
-      setLoading(false);
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (!mounted) return;
+        setSession(data.session ?? null);
+        setUser(data.session?.user ?? null);
+      } catch (error) {
+        console.error('Error fetching session', error);
+        alert('Erreur lors de la récupération de la session.');
+      } finally {
+        if (mounted) setLoading(false);
+      }
     })();
 
     const { data: sub } = supabase.auth.onAuthStateChange((_event, newSession) => {
@@ -81,9 +87,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     },
     signOut: async () => { await supabase.auth.signOut(); },
     refresh: async () => {
-      const { data } = await supabase.auth.getSession();
-      setSession(data.session ?? null);
-      setUser(data.session?.user ?? null);
+      try {
+        const { data } = await supabase.auth.getSession();
+        setSession(data.session ?? null);
+        setUser(data.session?.user ?? null);
+      } catch (error) {
+        console.error('Error refreshing session', error);
+        alert('Erreur lors de la récupération de la session.');
+      }
     },
   }), [user, session, loading]);
 


### PR DESCRIPTION
## Summary
- prevent indefinite loading by catching errors when retrieving the auth session
- surface session refresh failures to the user

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689f756c4e90832b91c522c216f5c239