### PR TITLE
Wrap App in StrictMode only in production and guard initial product load

### DIFF
--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -78,6 +78,7 @@ const PerfumeCatalog = ({
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 20;
   const fetchGuardRef = useRef({ includeInactive, loaded: false });
+  const loadedRef = useRef(false);
 
   // Function to load products directly from Supabase
   const loadProductsFromSupabase = useCallback(async () => {
@@ -157,6 +158,8 @@ const PerfumeCatalog = ({
       setLoading(false);
       fetchGuardRef.current = { includeInactive, loaded: true };
     } else {
+      if (loadedRef.current) return;
+      loadedRef.current = true;
       loadProductsFromSupabase();
     }
   }, [perfumes, includeInactive, loadProductsFromSupabase]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,16 +10,14 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 
 const app = (
   <BrowserRouter>
-    <App />
+    {import.meta.env.PROD ? (
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    ) : (
+      <App />
+    )}
   </BrowserRouter>
 );
 
-if (import.meta.env.PROD) {
-  root.render(
-    <React.StrictMode>
-      {app}
-    </React.StrictMode>
-  );
-} else {
-  root.render(app);
-}
+root.render(app);


### PR DESCRIPTION
## Summary
- Render React StrictMode only for production builds
- Prevent duplicate Supabase fetch on development double render

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f6907b88832b8528849bc734eaea