### PR TITLE
Use React.lazy for route components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { Suspense } from "react";
+import { Suspense, lazy } from "react";
 import { useRoutes, Routes, Route } from "react-router-dom";
-import Home from "./components/home";
-import ClientSpace from "./components/ClientSpace";
-import ConseillerSpace from "./components/ConseillerSpace";
-import AdminSpace from "./components/AdminSpace";
+const Home = lazy(() => import("./components/home"));
+const ClientSpace = lazy(() => import("./components/ClientSpace"));
+const ConseillerSpace = lazy(() => import("./components/ConseillerSpace"));
+const AdminSpace = lazy(() => import("./components/AdminSpace"));
 import { CartProvider } from "./contexts/CartContext";
 import { AuthProvider } from "./contexts/AuthContext";
 import { FavoritesProvider } from "./contexts/FavoritesContext";
@@ -16,17 +16,43 @@ function App() {
     <AuthProvider>
       <CartProvider>
         <FavoritesProvider>
-          <Suspense fallback={<p>Loading...</p>}>
-            <>
-              <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/client" element={<ClientSpace />} />
-                <Route path="/conseillere" element={<ConseillerSpace />} />
-                <Route path="/admin" element={<AdminSpace />} />
-              </Routes>
-              {tempoRoutes}
-            </>
-          </Suspense>
+          <>
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <Home />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/client"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <ClientSpace />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/conseillere"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <ConseillerSpace />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/admin"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <AdminSpace />
+                  </Suspense>
+                }
+              />
+            </Routes>
+            {tempoRoutes}
+          </>
         </FavoritesProvider>
       </CartProvider>
     </AuthProvider>


### PR DESCRIPTION
## Summary
- Lazy load Home, ClientSpace, ConseillerSpace, and AdminSpace using `React.lazy`
- Apply per-route `<Suspense>` fallbacks and remove global wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbf47b58832b84efcd3b1be000af