### PR TITLE
refactor: replace simple animations with css

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { Suspense } from "react";
+import { Suspense, lazy } from "react";
 import { useRoutes, Routes, Route } from "react-router-dom";
-import Home from "./components/home";
-import ClientSpace from "./components/ClientSpace";
-import ConseillerSpace from "./components/ConseillerSpace";
-import AdminSpace from "./components/AdminSpace";
+const Home = lazy(() => import("./components/home"));
+const ClientSpace = lazy(() => import("./components/ClientSpace"));
+const ConseillerSpace = lazy(() => import("./components/ConseillerSpace"));
+const AdminSpace = lazy(() => import("./components/AdminSpace"));
 import { CartProvider } from "./contexts/CartContext";
 import { AuthProvider } from "./contexts/AuthContext";
 import { FavoritesProvider } from "./contexts/FavoritesContext";
@@ -16,17 +16,43 @@ function App() {
     <AuthProvider>
       <CartProvider>
         <FavoritesProvider>
-          <Suspense fallback={<p>Loading...</p>}>
-            <>
-              <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/client" element={<ClientSpace />} />
-                <Route path="/conseillere" element={<ConseillerSpace />} />
-                <Route path="/admin" element={<AdminSpace />} />
-              </Routes>
-              {tempoRoutes}
-            </>
-          </Suspense>
+          <>
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <Home />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/client"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <ClientSpace />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/conseillere"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <ConseillerSpace />
+                  </Suspense>
+                }
+              />
+              <Route
+                path="/admin"
+                element={
+                  <Suspense fallback={<p>Loading...</p>}>
+                    <AdminSpace />
+                  </Suspense>
+                }
+              />
+            </Routes>
+            {tempoRoutes}
+          </>
         </FavoritesProvider>
       </CartProvider>
     </AuthProvider>

--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { motion } from "framer-motion";
 import HomeLayout from "./HomeLayout";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
@@ -114,6 +113,7 @@ const AdminSpace = () => {
 
   const [orders, setOrders] = useState([]);
   const [filteredOrders, setFilteredOrders] = useState([]);
+  const [mounted, setMounted] = useState(false);
 
   // Enhanced data loading with RLS diagnostics
   const loadData = async () => {
@@ -431,6 +431,11 @@ const AdminSpace = () => {
     return () => {
       window.removeEventListener("usersImported", handleUsersImported);
     };
+  }, []);
+
+  useEffect(() => {
+    const t = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(t);
   }, []);
 
   useEffect(() => {
@@ -2652,11 +2657,10 @@ const AdminSpace = () => {
   return (
     <div className="min-h-screen bg-[#FBF0E9] p-4">
       <div className="max-w-7xl mx-auto">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="space-y-8"
+        <div
+          className={`space-y-8 transition-all duration-500 ${
+            mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5"
+          }`}
         >
           <div className="flex justify-between items-center mb-8">
             <div className="text-center flex-1">
@@ -3951,7 +3955,7 @@ const AdminSpace = () => {
               </Card>
             </TabsContent>
           </Tabs>
-        </motion.div>
+        </div>
       </div>
 
       {/* New Product Dialog */}

--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -63,7 +63,7 @@ import { supabase } from "../lib/supabaseClient";
 const AdminSpace = () => {
   const { register } = useAuth();
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedProduct, setSelectedProduct] = useState(null);
+  const [selectedProduct, setSelectedProduct] = useState<any>(null);
   const today = new Date().toISOString().split("T")[0];
   const [dateFilter, setDateFilter] = useState({ start: today, end: today });
   const [showLogin, setShowLogin] = useState(true);
@@ -83,7 +83,7 @@ const AdminSpace = () => {
   const [selectedPromotion, setSelectedPromotion] = useState(null);
   const [selectedProductForRestock, setSelectedProductForRestock] =
     useState(null);
-  const [editFormData, setEditFormData] = useState({});
+  const [editFormData, setEditFormData] = useState<any>({});
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(
     null,
   );
@@ -1514,7 +1514,7 @@ const AdminSpace = () => {
                 ];
 
                 // Create product with properly encoded data
-                const newProduct = {
+                const newProduct: any = {
                   id: Date.now() + i,
                   codeArticle: fixEncoding(codeArticle),
                   name: fixEncoding(nomLolly),

--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -64,7 +64,8 @@ const AdminSpace = () => {
   const { register } = useAuth();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedProduct, setSelectedProduct] = useState(null);
-  const [dateFilter, setDateFilter] = useState({ start: "", end: "" });
+  const today = new Date().toISOString().split("T")[0];
+  const [dateFilter, setDateFilter] = useState({ start: today, end: today });
   const [showLogin, setShowLogin] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [showNewProduct, setShowNewProduct] = useState(false);
@@ -110,6 +111,7 @@ const AdminSpace = () => {
   const [promotions, setPromotions] = useState([]);
 
   const [orders, setOrders] = useState([]);
+  const [filteredOrders, setFilteredOrders] = useState([]);
 
   // Enhanced data loading with RLS diagnostics
   const loadData = async () => {
@@ -462,6 +464,19 @@ const AdminSpace = () => {
     return () =>
       window.removeEventListener("newSaleRecorded", handleNewSale);
   }, []);
+
+  useEffect(() => {
+    const today = new Date().toISOString().split("T")[0];
+    if (dateFilter.start && dateFilter.end) {
+      setFilteredOrders(
+        orders.filter(
+          (o) => o.date >= dateFilter.start && o.date <= dateFilter.end,
+        ),
+      );
+    } else {
+      setFilteredOrders(orders.filter((o) => o.date === today));
+    }
+  }, [orders, dateFilter.start, dateFilter.end]);
 
   const handleExportExcel = (type) => {
     // Create CSV content with UTF-8 BOM for Excel compatibility
@@ -3327,7 +3342,7 @@ const AdminSpace = () => {
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {orders.map((sale) => (
+                        {filteredOrders.map((sale) => (
                           <TableRow key={sale.id}>
                             <TableCell>{sale.date}</TableCell>
                             <TableCell>{sale.client}</TableCell>

--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -4317,7 +4317,7 @@ const AdminSpace = () => {
                     for (const variant of variants) {
                       await supabase.from("product_variants").insert({
                         product_id: newProduct.id,
-                        ref_complete: `${newProduct.code_produit}-${variant.size}`,
+                        ref_complete: `${newProduct.code_produit}-${parseInt(variant.size)}`,
                         contenance: parseInt(variant.size),
                         unite: "ml",
                         prix: variant.price,

--- a/src/components/ClientSpace.tsx
+++ b/src/components/ClientSpace.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { motion } from "framer-motion";
 import PerfumeCatalog from "./catalog/PerfumeCatalog";
 import PerfumeDetail from "./catalog/PerfumeDetail";
 import { Button } from "./ui/button";
@@ -161,6 +160,7 @@ const ClientSpace = () => {
   const [showAccount, setShowAccount] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editedUser, setEditedUser] = useState<any>(null);
+  const [mounted, setMounted] = useState(false);
   const { getTotalItems } = useCart();
   const { favorites, removeFromFavorites } = useFavorites();
   const { isAuthenticated, user, updateUser, signOut } = useAuth();
@@ -174,6 +174,11 @@ const ClientSpace = () => {
       window.location.href = "/conseillere";
     }
   }, [isAuthenticated, user]);
+
+  React.useEffect(() => {
+    const t = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
 
   // Listen for login dialog events from other components
   React.useEffect(() => {
@@ -269,11 +274,10 @@ const ClientSpace = () => {
     <div className="min-h-screen bg-[#FBF0E9] p-4">
       <div className="max-w-7xl mx-auto">
         {/* Header with Logo and Title */}
-        <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="flex flex-col items-center mb-8"
+        <div
+          className={`flex flex-col items-center mb-8 transition-all duration-500 ${
+            mounted ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-5"
+          }`}
         >
           <div className="w-24 h-24 mb-4 rounded-full bg-white flex items-center justify-center shadow-md p-2">
             <img
@@ -285,13 +289,12 @@ const ClientSpace = () => {
           <h1 className="text-3xl md:text-4xl font-playfair text-[#805050] mb-4 text-center">
             Le Compas Olfactif
           </h1>
-        </motion.div>
+        </div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="space-y-8"
+        <div
+          className={`space-y-8 transition-all duration-500 ${
+            mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5"
+          }`}
         >
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-8">
             <div className="text-center sm:text-left flex-1">
@@ -791,7 +794,7 @@ const ClientSpace = () => {
           ) : (
             <PerfumeCatalog onPerfumeSelect={handlePerfumeSelect} />
           )}
-        </motion.div>
+        </div>
       </div>
 
       <CartDialog open={showCart} onOpenChange={setShowCart} />

--- a/src/components/ConseillerSpace.tsx
+++ b/src/components/ConseillerSpace.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { motion } from "framer-motion";
 import {
   Card,
   CardContent,
@@ -46,6 +45,7 @@ const ConseillerSpace = () => {
   const [showClientLogin, setShowClientLogin] = useState(false);
   const [currentClient, setCurrentClient] = useState<any>(null);
   const [showFavorites, setShowFavorites] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
   // Initialize data
   const [salesData, setSalesData] = useState(() => {
@@ -130,6 +130,11 @@ const ConseillerSpace = () => {
       setIsLoading(false);
     }
   }, [isAuthenticated, user]);
+
+  useEffect(() => {
+    const t = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
 
   // Filter sales by date range
   useEffect(() => {
@@ -391,11 +396,10 @@ const ConseillerSpace = () => {
   return (
     <div className="min-h-screen bg-[#FBF0E9] p-4">
       <div className="max-w-7xl mx-auto">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="space-y-8"
+        <div
+          className={`space-y-8 transition-all duration-500 ${
+            mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5"
+          }`}
         >
           <div className="flex justify-between items-center mb-8">
             <div className="text-center flex-1">
@@ -831,7 +835,7 @@ const ConseillerSpace = () => {
               </Card>
             </TabsContent>
           </Tabs>
-        </motion.div>
+        </div>
       </div>
 
       <ClientLoginDialog

--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -1,18 +1,23 @@
 import React from "react";
-import { motion } from "framer-motion";
 
 interface HomeLayoutProps {
   children?: React.ReactNode;
 }
 
 const HomeLayout = ({ children = null }: HomeLayoutProps) => {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    const t = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-start py-10 px-4 bg-[#FBF0E9]">
-      <motion.div
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-        className="flex flex-col items-center"
+      <div
+        className={`flex flex-col items-center transition-all duration-500 ${
+          mounted ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-5"
+        }`}
       >
         {/* Logo */}
         <div className="w-32 h-32 mb-4 rounded-full bg-white flex items-center justify-center shadow-md p-2">
@@ -27,20 +32,17 @@ const HomeLayout = ({ children = null }: HomeLayoutProps) => {
         <h1 className="text-4xl md:text-5xl font-playfair text-[#805050] mb-12 text-center">
           Le Compas Olfactif
         </h1>
-      </motion.div>
+      </div>
       {/* Access Buttons */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, delay: 0.3 }}
-        className="w-full max-w-2xl mb-12"
+      <div
+        className={`w-full max-w-2xl mb-12 transition-all duration-500 delay-300 ${
+          mounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-5"
+        }`}
       >
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Client Button */}
-          <motion.button
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="bg-[#CE8F8A] hover:bg-[#B87B76] text-white font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
+          <button
+            className="bg-[#CE8F8A] hover:bg-[#B87B76] text-white font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-transform duration-300 flex flex-col items-center space-y-2 hover:scale-105 active:scale-95"
             onClick={() => (window.location.href = "/client")}
           >
             <div className="w-10 h-10 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
@@ -48,13 +50,11 @@ const HomeLayout = ({ children = null }: HomeLayoutProps) => {
             </div>
             <span className="text-base">Espace Client</span>
             <span className="text-xs opacity-90">Découvrir nos parfums</span>
-          </motion.button>
+          </button>
 
           {/* Conseillère Button */}
-          <motion.button
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="bg-[#D4C2A1] hover:bg-[#C4B291] text-[#805050] font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
+          <button
+            className="bg-[#D4C2A1] hover:bg-[#C4B291] text-[#805050] font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-transform duration-300 flex flex-col items-center space-y-2 hover:scale-105 active:scale-95"
             onClick={() => (window.location.href = "/conseillere")}
           >
             <div className="w-10 h-10 bg-white bg-opacity-30 rounded-full flex items-center justify-center">
@@ -62,13 +62,11 @@ const HomeLayout = ({ children = null }: HomeLayoutProps) => {
             </div>
             <span className="text-base">Espace Conseillère</span>
             <span className="text-xs opacity-90">Gérer les conseils</span>
-          </motion.button>
+          </button>
 
           {/* Admin Button */}
-          <motion.button
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="bg-[#805050] hover:bg-[#704040] text-white font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
+          <button
+            className="bg-[#805050] hover:bg-[#704040] text-white font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-transform duration-300 flex flex-col items-center space-y-2 hover:scale-105 active:scale-95"
             onClick={() => (window.location.href = "/admin")}
           >
             <div className="w-10 h-10 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
@@ -76,9 +74,9 @@ const HomeLayout = ({ children = null }: HomeLayoutProps) => {
             </div>
             <span className="text-base">Espace Admin</span>
             <span className="text-xs opacity-90">Administration</span>
-          </motion.button>
+          </button>
         </div>
-      </motion.div>
+      </div>
       {/* Content area */}
       <div className="w-full max-w-4xl">{children}</div>
       {/* Footer */}

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -77,27 +77,30 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       const refs = items.map((item) => item.refComplete.replace(/ml$/, ""));
       const { data: variants, error: variantError } = await supabase
         .from("product_variants")
-        .select("id, ref_complete")
+        .select("id, ref_complete, stock_actuel")
         .in("ref_complete", refs);
       if (variantError) throw variantError;
       const variantMap = new Map(
-        variants.map((v: any) => [v.ref_complete.replace(/ml$/, ""), v.id]),
+        variants.map((v: any) => [
+          v.ref_complete.replace(/ml$/, ""),
+          { id: v.id, stock_actuel: v.stock_actuel },
+        ]),
       );
 
       // 3. Insert order items
       const orderItems = [] as any[];
       for (const item of items) {
-        const variantId = variantMap.get(
+        const variant = variantMap.get(
           item.refComplete.replace(/ml$/, ""),
         );
-        if (!variantId) {
+        if (!variant) {
           alert("Référence produit introuvable");
           setIsSubmitting(false);
           return;
         }
         orderItems.push({
           order_id: orderId,
-          product_variant_id: variantId,
+          product_variant_id: variant.id,
           quantity: item.quantity,
           unit_price: item.prix,
           total_price: item.prix * item.quantity,
@@ -107,6 +110,64 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
         .from("order_items")
         .insert(orderItems);
       if (itemsError) throw itemsError;
+
+      // 3b. Update stock and record movements
+      const updatedVariants: { id: string; previousStock: number }[] = [];
+      const movementIds: string[] = [];
+      try {
+        for (const item of items) {
+          const variant = variantMap.get(
+            item.refComplete.replace(/ml$/, ""),
+          );
+          if (!variant) continue;
+          const previousStock = variant.stock_actuel || 0;
+          const newStock = previousStock - item.quantity;
+          const { error: stockError } = await supabase
+            .from("product_variants")
+            .update({ stock_actuel: newStock })
+            .eq("id", variant.id);
+          if (stockError) throw stockError;
+          updatedVariants.push({ id: variant.id, previousStock });
+
+          const { data: movement, error: movementError } = await supabase
+            .from("stock_movements")
+            .insert({
+              product_variant_id: variant.id,
+              type: "sortie",
+              quantity: -item.quantity,
+              reason: "Commande client",
+              reference_document: `order:${orderId}`,
+              created_by: user?.id,
+            })
+            .select("id")
+            .single();
+          if (movementError) throw movementError;
+          movementIds.push(movement.id);
+
+          window.dispatchEvent(
+            new CustomEvent("stockUpdated", {
+              detail: { variantId: variant.id, newStock },
+            }),
+          );
+        }
+      } catch (stockErr) {
+        // Rollback stock updates and order in case of failure
+        for (const u of updatedVariants) {
+          await supabase
+            .from("product_variants")
+            .update({ stock_actuel: u.previousStock })
+            .eq("id", u.id);
+        }
+        if (movementIds.length) {
+          await supabase
+            .from("stock_movements")
+            .delete()
+            .in("id", movementIds);
+        }
+        await supabase.from("order_items").delete().eq("order_id", orderId);
+        await supabase.from("orders").delete().eq("id", orderId);
+        throw stockErr;
+      }
 
       // 4. Store order locally
       const orderData = {

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -74,7 +74,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       const orderId = newOrder.id;
 
       // 2. Fetch product variant ids for items in cart
-      const refs = items.map((item) => item.refComplete.replace(/ml$/, ""));
+      const refs = items.map((item) => item.refComplete);
       const { data: variants, error: variantError } = await supabase
         .from("product_variants")
         .select("id, ref_complete, stock_actuel")
@@ -82,7 +82,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       if (variantError) throw variantError;
       const variantMap = new Map(
         variants.map((v: any) => [
-          v.ref_complete.replace(/ml$/, ""),
+          v.ref_complete,
           { id: v.id, stock_actuel: v.stock_actuel },
         ]),
       );
@@ -90,9 +90,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       // 3. Insert order items
       const orderItems = [] as any[];
       for (const item of items) {
-        const variant = variantMap.get(
-          item.refComplete.replace(/ml$/, ""),
-        );
+        const variant = variantMap.get(item.refComplete);
         if (!variant) {
           alert("Référence produit introuvable");
           setIsSubmitting(false);
@@ -116,9 +114,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
       const movementIds: string[] = [];
       try {
         for (const item of items) {
-          const variant = variantMap.get(
-            item.refComplete.replace(/ml$/, ""),
-          );
+          const variant = variantMap.get(item.refComplete);
           if (!variant) continue;
           const previousStock = variant.stock_actuel || 0;
           const newStock = previousStock - item.quantity;

--- a/src/components/catalog/PerfumeCard.tsx
+++ b/src/components/catalog/PerfumeCard.tsx
@@ -40,6 +40,22 @@ const PerfumeCard = ({
   const { addToFavorites, removeFromFavorites, isFavorite } = useFavorites();
   const { isAuthenticated } = useAuth();
 
+  const buildSrcSet = (url: string) => {
+    try {
+      return [200, 400, 800]
+        .map((size) => {
+          const u = new URL(url);
+          u.searchParams.set("w", size.toString());
+          return `${u.toString()} ${size}w`;
+        })
+        .join(", ");
+    } catch {
+      return undefined;
+    }
+  };
+
+  const srcSet = buildSrcSet(imageURL);
+
   const handleAddToFavorites = (e: React.MouseEvent) => {
     e.stopPropagation();
 
@@ -101,6 +117,10 @@ const PerfumeCard = ({
           src={imageURL}
           alt={nomLolly}
           className="w-full h-full object-cover transition-transform duration-500 hover:scale-105"
+          loading="lazy"
+          decoding="async"
+          srcSet={srcSet}
+          sizes={srcSet ? "(max-width: 600px) 100vw, 400px" : undefined}
         />
         <div className="absolute top-2 left-2 bg-[#CE8F8A] text-white text-xs px-2 py-1 rounded">
           {codeProduit}

--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -50,16 +50,14 @@ const PerfumeCatalog = ({
   const [selectedFamille, setSelectedFamille] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 20;
-  const hasFetchedRef = useRef(false);
+  const loadedRef = useRef(false);
 
   // Function to load products directly from Supabase
-  const loadProductsFromSupabase = useCallback(
-    async (force = false) => {
-      if (hasFetchedRef.current && !force) {
-        console.log("⏭️ Products already loaded, skipping fetch");
-        return;
-      }
-      hasFetchedRef.current = true;
+  const loadProductsFromSupabase = useCallback(async () => {
+    if (loadedRef.current) {
+      return;
+    }
+    loadedRef.current = true;
 
       try {
         setLoading(true);
@@ -116,24 +114,22 @@ const PerfumeCatalog = ({
           console.log("No products found in Supabase, using default perfumes");
           setCatalogPerfumes(defaultPerfumes);
         }
-      } catch (error) {
-        console.error("Error loading products from Supabase:", error);
-        setCatalogPerfumes(defaultPerfumes);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [includeInactive],
-  );
+    } catch (error) {
+      console.error("Error loading products from Supabase:", error);
+      setCatalogPerfumes(defaultPerfumes);
+    } finally {
+      setLoading(false);
+    }
+  }, [includeInactive]);
 
   // Load products on component mount
   useEffect(() => {
     if (perfumes) {
       setCatalogPerfumes(perfumes);
       setLoading(false);
-      hasFetchedRef.current = true;
+      loadedRef.current = true;
     } else {
-      hasFetchedRef.current = false;
+      loadedRef.current = false;
       loadProductsFromSupabase();
     }
   }, [perfumes, includeInactive, loadProductsFromSupabase]);
@@ -144,13 +140,15 @@ const PerfumeCatalog = ({
       console.log(
         "🔄 Catalog update event received, reloading from Supabase...",
       );
-      loadProductsFromSupabase(true);
+      loadedRef.current = false;
+      loadProductsFromSupabase();
     };
 
     const handleCatalogClear = () => {
       console.log("🗑️ Catalog clear event received, clearing and reloading...");
       setCatalogPerfumes([]);
-      loadProductsFromSupabase(true);
+      loadedRef.current = false;
+      loadProductsFromSupabase();
     };
 
     window.addEventListener("catalogUpdated", handleCatalogUpdate);

--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -14,26 +14,16 @@ import {
 import PerfumeCard from "./PerfumeCard";
 import { supabase } from "@/lib/supabaseClient";
 
-// Simple debounce hook to delay invoking a callback until after a pause
-const useDebouncedCallback = (
-  callback: (value: string) => void,
-  delay: number,
-) => {
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
-
-  const debounced = useCallback(
-    (value: string) => {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(() => callback(value), delay);
-    },
-    [callback, delay],
-  );
+// Hook returning a debounced value after a specified delay
+const useDebounce = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {
-    return () => clearTimeout(timeoutRef.current);
-  }, [debounced]);
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
 
-  return debounced;
+  return debouncedValue;
 };
 
 interface PerfumeType {
@@ -66,12 +56,8 @@ const PerfumeCatalog = ({
   // All useState hooks must be called before any early returns
   const [catalogPerfumes, setCatalogPerfumes] = useState<PerfumeType[]>([]);
   const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState("");
   const [searchInput, setSearchInput] = useState("");
-  const debouncedSetSearchTerm = useDebouncedCallback(
-    (value: string) => setSearchTerm(value),
-    300,
-  );
+  const searchTerm = useDebounce(searchInput, 300);
   const [selectedGenre, setSelectedGenre] = useState<string | null>(null);
   const [selectedSaison, setSelectedSaison] = useState<string | null>(null);
   const [selectedFamille, setSelectedFamille] = useState<string | null>(null);
@@ -259,9 +245,7 @@ const PerfumeCatalog = ({
   const handleSearchChange = (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const value = e.target.value;
-    setSearchInput(value);
-    debouncedSetSearchTerm(value);
+    setSearchInput(e.target.value);
   };
 
   const handleGenreSelect = (genre: string) => {
@@ -278,7 +262,6 @@ const PerfumeCatalog = ({
 
   const clearFilters = () => {
     setSearchInput("");
-    setSearchTerm("");
     setSelectedGenre(null);
     setSelectedSaison(null);
     setSelectedFamille(null);

--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -78,6 +78,7 @@ const PerfumeCatalog = ({
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 20;
   const fetchGuardRef = useRef({ includeInactive, loaded: false });
+  const loadedRef = useRef(false);
 
   // Function to load products directly from Supabase
   const loadProductsFromSupabase = useCallback(async () => {
@@ -157,6 +158,8 @@ const PerfumeCatalog = ({
       setLoading(false);
       fetchGuardRef.current = { includeInactive, loaded: true };
     } else {
+      if (loadedRef.current) return;
+      loadedRef.current = true;
       loadProductsFromSupabase();
     }
   }, [perfumes, includeInactive, loadProductsFromSupabase]);

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -1,18 +1,23 @@
 import React from "react";
-import { motion } from "framer-motion";
 import HomeLayout from "./HomeLayout";
 
 const Home = () => {
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    const t = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
+
   return (
     <div className="min-h-screen bg-[#FBF0E9] flex flex-col items-center justify-center p-4">
-      <motion.div
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8 }}
-        className="w-full max-w-4xl h-[600px]"
+      <div
+        className={`w-full max-w-4xl h-[600px] transition-all duration-700 ${
+          mounted ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-5"
+        }`}
       >
         <HomeLayout />
-      </motion.div>
+      </div>
     </div>
   );
 };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,19 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import type { Session, User } from '@supabase/supabase-js';
+import type { Session, User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabaseClient';
+import { login as loginService, register as registerService } from '@/services/auth/authService';
+
+// Extend Supabase's User type with application-specific fields.
+interface User extends SupabaseUser {
+  nom?: string;
+  prenom?: string;
+  telephone?: string;
+  whatsapp?: string;
+  dateNaissance?: string;
+  adresse?: string;
+  role?: string;
+  codeClient?: string;
+}
 
 type AuthCtx = {
   user: User | null;
@@ -10,6 +23,8 @@ type AuthCtx = {
   updateUser: (u: Partial<User>) => void;
   signOut: () => Promise<void>;
   refresh: () => Promise<void>;
+  login: (email: string, password: string) => Promise<boolean>;
+  register: (data: any) => Promise<boolean>;
 };
 
 const Ctx = createContext<AuthCtx>({
@@ -20,6 +35,8 @@ const Ctx = createContext<AuthCtx>({
   updateUser: () => {},
   signOut: async () => {},
   refresh: async () => {},
+  login: async () => false,
+  register: async () => false,
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -95,6 +112,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         console.error('Error refreshing session', error);
         alert('Erreur lors de la récupération de la session.');
       }
+    },
+    login: async (email, password) => {
+      const res = await loginService(email, password);
+      if (res) {
+        setUser(res as User);
+        return true;
+      }
+      return false;
+    },
+    register: async (data: any) => {
+      const res = await registerService(data);
+      if (res) {
+        setUser(res as User);
+        return true;
+      }
+      return false;
     },
   }), [user, session, loading]);
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -52,11 +52,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     let mounted = true;
 
     (async () => {
-      const { data } = await supabase.auth.getSession();
-      if (!mounted) return;
-      setSession(data.session ?? null);
-      setUser(data.session?.user ?? null);
-      setLoading(false);
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (!mounted) return;
+        setSession(data.session ?? null);
+        setUser(data.session?.user ?? null);
+      } catch (error) {
+        console.error('Error fetching session', error);
+        alert('Erreur lors de la récupération de la session.');
+      } finally {
+        if (mounted) setLoading(false);
+      }
     })();
 
     const { data: sub } = supabase.auth.onAuthStateChange((_event, newSession) => {
@@ -81,9 +87,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     },
     signOut: async () => { await supabase.auth.signOut(); },
     refresh: async () => {
-      const { data } = await supabase.auth.getSession();
-      setSession(data.session ?? null);
-      setUser(data.session?.user ?? null);
+      try {
+        const { data } = await supabase.auth.getSession();
+        setSession(data.session ?? null);
+        setUser(data.session?.user ?? null);
+      } catch (error) {
+        console.error('Error refreshing session', error);
+        alert('Erreur lors de la récupération de la session.');
+      }
     },
   }), [user, session, loading]);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,16 +10,14 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 
 const app = (
   <BrowserRouter>
-    <App />
+    {import.meta.env.PROD ? (
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    ) : (
+      <App />
+    )}
   </BrowserRouter>
 );
 
-if (import.meta.env.PROD) {
-  root.render(
-    <React.StrictMode>
-      {app}
-    </React.StrictMode>
-  );
-} else {
-  root.render(app);
-}
+root.render(app);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,10 +6,20 @@ import App from './App';
 // ⚠️ Très important: import du CSS global (Tailwind, etc.)
 import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>,
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+
+const app = (
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
 );
+
+if (import.meta.env.PROD) {
+  root.render(
+    <React.StrictMode>
+      {app}
+    </React.StrictMode>
+  );
+} else {
+  root.render(app);
+}

--- a/src/types/tempo-routes.d.ts
+++ b/src/types/tempo-routes.d.ts
@@ -1,0 +1,1 @@
+declare module 'tempo-routes';

--- a/supabase/migrations/20250120000001_create_perfume_shop_tables.sql
+++ b/supabase/migrations/20250120000001_create_perfume_shop_tables.sql
@@ -98,8 +98,12 @@ CREATE TABLE IF NOT EXISTS public.promotions (
 );
 
 -- (idempotence pour les promotions)
-ALTER TABLE public.promotions
-  ADD CONSTRAINT IF NOT EXISTS promotions_unique_nom_dates UNIQUE (nom, date_debut, date_fin);
+DO $$
+BEGIN
+  ALTER TABLE public.promotions
+    ADD CONSTRAINT promotions_unique_nom_dates UNIQUE (nom, date_debut, date_fin);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- Create stock movements table for tracking inventory changes
 CREATE TABLE IF NOT EXISTS public.stock_movements (

--- a/supabase/migrations/20250120000001_create_perfume_shop_tables.sql
+++ b/supabase/migrations/20250120000001_create_perfume_shop_tables.sql
@@ -102,7 +102,9 @@ DO $$
 BEGIN
   ALTER TABLE public.promotions
     ADD CONSTRAINT promotions_unique_nom_dates UNIQUE (nom, date_debut, date_fin);
-EXCEPTION WHEN duplicate_object THEN NULL;
+EXCEPTION
+  WHEN duplicate_object OR duplicate_table THEN
+    NULL;
 END $$;
 
 -- Create stock movements table for tracking inventory changes

--- a/supabase/migrations/20250901000000_remove_ml_suffix_from_ref_complete.sql
+++ b/supabase/migrations/20250901000000_remove_ml_suffix_from_ref_complete.sql
@@ -1,0 +1,5 @@
+-- Remove trailing 'ml' from ref_complete values
+UPDATE product_variants
+SET ref_complete = regexp_replace(ref_complete, 'ml$', '')
+WHERE ref_complete LIKE '%ml';
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,87 +4,94 @@ import react from "@vitejs/plugin-react-swc";
 import { tempo } from "tempo-devtools/dist/vite";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: "/",
-  cacheDir: "node_modules/.vite-cache",
-  optimizeDeps: {
-    entries: ["src/main.tsx", "src/tempobook/**/*"],
-    force: true,
-    include: [
-      "react",
-      "react-dom",
-      "react-router-dom",
-      "framer-motion",
-      "lucide-react",
-      "@radix-ui/react-dialog",
-      "@radix-ui/react-tabs",
+export default defineConfig(({ mode }) => {
+  const config = {
+    base: "/",
+    cacheDir: "node_modules/.vite-cache",
+    optimizeDeps: {
+      entries: ["src/main.tsx", "src/tempobook/**/*"],
+      force: true,
+      include: [
+        "react",
+        "react-dom",
+        "react-router-dom",
+        "framer-motion",
+        "lucide-react",
+        "@radix-ui/react-dialog",
+        "@radix-ui/react-tabs",
 
-      "@radix-ui/react-label",
-      "@radix-ui/react-select",
-      "@radix-ui/react-switch",
-      "@radix-ui/react-tooltip",
-      "@radix-ui/react-accordion",
-      "@radix-ui/react-alert-dialog",
-      "@radix-ui/react-aspect-ratio",
-      "@radix-ui/react-avatar",
-      "@radix-ui/react-checkbox",
-      "@radix-ui/react-collapsible",
-      "@radix-ui/react-context-menu",
-      "@radix-ui/react-dropdown-menu",
-      "@radix-ui/react-hover-card",
-      "@radix-ui/react-menubar",
-      "@radix-ui/react-navigation-menu",
-      "@radix-ui/react-popover",
-      "@radix-ui/react-progress",
-      "@radix-ui/react-radio-group",
-      "@radix-ui/react-scroll-area",
-      "@radix-ui/react-separator",
-      "@radix-ui/react-slider",
-      "@radix-ui/react-toast",
-      "@radix-ui/react-toggle",
-      "class-variance-authority",
-      "clsx",
-      "tailwind-merge",
-    ],
-  },
-  plugins: [react(), tempo()],
-  resolve: {
-    preserveSymlinks: false,
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+        "@radix-ui/react-label",
+        "@radix-ui/react-select",
+        "@radix-ui/react-switch",
+        "@radix-ui/react-tooltip",
+        "@radix-ui/react-accordion",
+        "@radix-ui/react-alert-dialog",
+        "@radix-ui/react-aspect-ratio",
+        "@radix-ui/react-avatar",
+        "@radix-ui/react-checkbox",
+        "@radix-ui/react-collapsible",
+        "@radix-ui/react-context-menu",
+        "@radix-ui/react-dropdown-menu",
+        "@radix-ui/react-hover-card",
+        "@radix-ui/react-menubar",
+        "@radix-ui/react-navigation-menu",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-progress",
+        "@radix-ui/react-radio-group",
+        "@radix-ui/react-scroll-area",
+        "@radix-ui/react-separator",
+        "@radix-ui/react-slider",
+        "@radix-ui/react-toast",
+        "@radix-ui/react-toggle",
+        "class-variance-authority",
+        "clsx",
+        "tailwind-merge",
+      ],
     },
-  },
-  server: {
-    // @ts-ignore
-    allowedHosts: process.env.TEMPO === "true" ? true : undefined,
-    host: true,
-    port: 5173,
-  },
-  build: {
-    target: "esnext",
-    minify: "esbuild",
-    sourcemap: false,
-    rollupOptions: {
-      output: {
-        entryFileNames: `assets/[name]-[hash].js`,
-        chunkFileNames: `assets/[name]-[hash].js`,
-        assetFileNames: `assets/[name]-[hash].[ext]`,
-        manualChunks: {
-          vendor: ["react", "react-dom"],
-          router: ["react-router-dom"],
-          ui: ["@radix-ui/react-dialog", "@radix-ui/react-tabs"],
+    plugins: process.env.VITE_TEMPO === "true" ? [react(), tempo()] : [react()],
+    resolve: {
+      preserveSymlinks: false,
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    server: {
+      // @ts-ignore
+      allowedHosts: process.env.TEMPO === "true" ? true : undefined,
+      host: true,
+      port: 5173,
+    },
+    build: {
+      target: "esnext",
+      minify: "esbuild",
+      sourcemap: false,
+      rollupOptions: {
+        output: {
+          entryFileNames: `assets/[name]-[hash].js`,
+          chunkFileNames: `assets/[name]-[hash].js`,
+          assetFileNames: `assets/[name]-[hash].[ext]`,
+          manualChunks: {
+            vendor: ["react", "react-dom"],
+            router: ["react-router-dom"],
+            ui: ["@radix-ui/react-dialog", "@radix-ui/react-tabs"],
+          },
         },
       },
     },
-  },
-  esbuild: {
-    logOverride: { "this-is-undefined-in-esm": "silent" },
-    target: "esnext",
-    keepNames: true,
-  },
-  define: {
-    __DEV__: JSON.stringify(true),
-    "process.env.NODE_ENV": JSON.stringify("development"),
-  },
-  clearScreen: false,
+    esbuild: {
+      logOverride: { "this-is-undefined-in-esm": "silent" },
+      target: "esnext",
+      keepNames: true,
+    },
+    clearScreen: false,
+  } as any;
+
+  if (mode === "development") {
+    config.define = {
+      __DEV__: JSON.stringify(true),
+      "process.env.NODE_ENV": JSON.stringify("development"),
+    };
+  }
+
+  return config;
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig(({ mode }) => {
         "react",
         "react-dom",
         "react-router-dom",
-        "framer-motion",
         "lucide-react",
         "@radix-ui/react-dialog",
         "@radix-ui/react-tabs",


### PR DESCRIPTION
## Summary
- remove framer-motion usage in home and layout components
- implement mount-based CSS transitions across client, conseiller, and admin areas
- drop framer-motion from Vite optimizeDeps

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `VITE_TEMPO=true npx vite build`
- `grep -R "framer-motion" dist -n`

------
https://chatgpt.com/codex/tasks/task_e_68a10158e7c4832bb2e58808aaed56d6