### PR TITLE
Add placeholder tempo routes and conditional alias

### DIFF
--- a/src/tempo-routes.ts
+++ b/src/tempo-routes.ts
@@ -1,0 +1,1 @@
+export default [] as any[];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,16 @@ import { tempo } from "tempo-devtools/dist/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
+  const isTempo = process.env.VITE_TEMPO === "true";
+  const alias: Record<string, string> = {
+    "@": path.resolve(__dirname, "./src"),
+    "tempo-routes": path.resolve(__dirname, "src/tempo-routes.ts"),
+  };
+
+  if (isTempo) {
+    delete alias["tempo-routes"];
+  }
+
   const config = {
     base: "/",
     cacheDir: "node_modules/.vite-cache",
@@ -48,12 +58,10 @@ export default defineConfig(({ mode }) => {
         "tailwind-merge",
       ],
     },
-    plugins: process.env.VITE_TEMPO === "true" ? [react(), tempo()] : [react()],
+    plugins: isTempo ? [react(), tempo()] : [react()],
     resolve: {
       preserveSymlinks: false,
-      alias: {
-        "@": path.resolve(__dirname, "./src"),
-      },
+      alias,
     },
     server: {
       // @ts-ignore


### PR DESCRIPTION
## Summary
- add stub `tempo-routes` module
- alias `tempo-routes` in Vite config and remove it when Tempo plugin runs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a109627310832b9096d2f62781016f