### PR TITLE
chore: load only needed font weights

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+@import "@fontsource/montserrat/400.css";
+@import "@fontsource/montserrat/600.css";
+@import "@fontsource/playfair-display/400.css";
+@import "@fontsource/playfair-display/600.css";
+
 @tailwind base;
   @tailwind components;
   @tailwind utilities;


### PR DESCRIPTION
## Summary
- import only the Montserrat and Playfair Display weights used by the app
- ensure font files specify `font-display: swap`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a10ac01efc832bac933c2c41364a9e