### PR TITLE
Optimize Supabase query payloads

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -2389,7 +2389,7 @@ const AdminSpace = () => {
                   // Find variant by contenance
                   const { data: variant } = await supabase
                     .from("product_variants")
-                    .select("*")
+                    .select("id, stock_actuel")
                     .eq("product_id", product.id)
                     .eq("contenance", stockItem.contenance)
                     .single();
@@ -2920,7 +2920,7 @@ const AdminSpace = () => {
                           try {
                             const { data, error } = await supabase
                               .from("users")
-                              .select("*")
+                              .select("id, email")
                               .limit(10);
 
                             console.log("📊 Direct Supabase test result:", {

--- a/src/features/auth/signIn.ts
+++ b/src/features/auth/signIn.ts
@@ -25,7 +25,7 @@ export async function handleSignIn(email: string, password: string) {
   // 2) Lire le profil PAR id (RLS: auth.uid() = id)
   const { data: profile, error: selErr } = await supabase
     .from('users')
-    .select('*')
+    .select('id, email')
     .eq('id', user.id)
     .maybeSingle();
   if (selErr) return { ok: false, step: 'selectProfile', error: selErr.message };

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -1,28 +1,71 @@
 import { supabase } from '../lib/supabaseClient';
 
 export const fetchUsers = () =>
-  supabase.from('users').select('*').order('created_at', { ascending: false });
+  supabase
+    .from('users')
+    .select(
+      'id, prenom, nom, email, role, telephone, whatsapp, date_naissance, adresse, code_client, created_at',
+    )
+    .order('created_at', { ascending: false })
+    .range(0, 99);
 
 export const fetchProducts = () =>
   supabase
     .from('products')
     .select(`
-      *,
-      product_variants(*)
-    `);
+      id,
+      code_produit,
+      nom_lolly,
+      nom_parfum_inspire,
+      marque_inspire,
+      active,
+      image_url,
+      genre,
+      saison,
+      famille_olfactive,
+      note_tete,
+      note_coeur,
+      note_fond,
+      description,
+      product_variants(
+        id,
+        contenance,
+        unite,
+        prix,
+        stock_actuel,
+        ref_complete,
+        actif
+      )
+    `)
+    .range(0, 99);
 
-export const fetchPromotions = () => supabase.from('promotions').select('*');
+export const fetchPromotions = () =>
+  supabase
+    .from('promotions')
+    .select('id, nom, pourcentage_reduction, description, date_debut, date_fin, active')
+    .order('date_debut', { ascending: false })
+    .range(0, 99);
 
 export const fetchOrders = () =>
-  supabase.from('orders').select(`
-    *,
-    client:users!orders_user_id_fkey(prenom, nom),
-    conseillere:users!orders_conseillere_id_fkey(prenom, nom),
-    order_items(
-      *,
-      product_variants(
-        *,
-        products(*)
+  supabase
+    .from('orders')
+    .select(`
+      id,
+      created_at,
+      code_client,
+      user_id,
+      conseillere_id,
+      client:users!orders_user_id_fkey(prenom, nom),
+      conseillere:users!orders_conseillere_id_fkey(prenom, nom),
+      order_items(
+        id,
+        total_price,
+        product_variant_id,
+        product_variants(
+          ref_complete,
+          products(nom_lolly)
+        )
       )
-    )
-  `);
+    `)
+    .order('created_at', { ascending: false })
+    .range(0, 99);

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -59,7 +59,9 @@ export async function login(
   try {
     const { data: existingUser, error: findError } = await supabase
       .from("users")
-      .select("*")
+      .select(
+        "id, email, nom, prenom, telephone, whatsapp, date_naissance, adresse, role, code_client",
+      )
       .eq("email", email)
       .single();
 


### PR DESCRIPTION
## Summary
- fetch only used columns from Supabase instead of `select('*')`
- add limits to major data queries to avoid loading entire tables
- narrow authentication queries to required user fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a11683ce34832ba66046822d508553