### PR TITLE
Add dashboard tab and summary

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 
+const DashboardTab = React.lazy(() => import("./admin/DashboardTab"));
 const ProductsTab = React.lazy(() => import("./admin/ProductsTab"));
 const UsersTab = React.lazy(() => import("./admin/UsersTab"));
 const PromotionsTab = React.lazy(() => import("./admin/PromotionsTab"));
@@ -8,14 +9,18 @@ const OrdersTab = React.lazy(() => import("./admin/OrdersTab"));
 
 const AdminSpace = () => {
   return (
-    <Tabs defaultValue="products" className="w-full">
-      <TabsList className="grid w-full grid-cols-4">
+    <Tabs defaultValue="dashboard" className="w-full">
+      <TabsList className="grid w-full grid-cols-5">
+        <TabsTrigger value="dashboard">Tableau de bord</TabsTrigger>
         <TabsTrigger value="products">Produits</TabsTrigger>
         <TabsTrigger value="users">Utilisateurs</TabsTrigger>
         <TabsTrigger value="promotions">Promotions</TabsTrigger>
         <TabsTrigger value="orders">Commandes</TabsTrigger>
       </TabsList>
       <Suspense fallback={<div>Chargement...</div>}>
+        <TabsContent value="dashboard">
+          <DashboardTab />
+        </TabsContent>
         <TabsContent value="products">
           <ProductsTab />
         </TabsContent>

--- a/src/components/admin/DashboardTab.tsx
+++ b/src/components/admin/DashboardTab.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import {
+  fetchProducts,
+  fetchUsers,
+  fetchPromotions,
+  fetchOrders,
+} from "../../services/admin";
+
+const DashboardTab: React.FC = () => {
+  const [stats, setStats] = useState({
+    products: 0,
+    users: 0,
+    promotions: 0,
+    orders: 0,
+  });
+
+  useEffect(() => {
+    Promise.all([
+      fetchProducts(),
+      fetchUsers(),
+      fetchPromotions(),
+      fetchOrders(),
+    ]).then(([p, u, promo, o]) => {
+      setStats({
+        products: (p.data || []).length,
+        users: (u.data || []).length,
+        promotions: (promo.data || []).length,
+        orders: (o.data || []).length,
+      });
+    });
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Résumé</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="grid grid-cols-2 gap-4">
+          <li>Produits: {stats.products}</li>
+          <li>Utilisateurs: {stats.users}</li>
+          <li>Promotions: {stats.promotions}</li>
+          <li>Commandes: {stats.orders}</li>
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DashboardTab;
+


### PR DESCRIPTION
## Summary
- add dashboard summary tab showing counts for products, users, promotions, and orders
- include dashboard tab in admin space navigation and default view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a config file)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a11bf7dbdc832bb382c74494c0fd09