### PR TITLE
feat: add pagination to products and streamline admin fetch

### DIFF
--- a/src/components/admin/ProductsTab.tsx
+++ b/src/components/admin/ProductsTab.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import { Button } from "../ui/button";
 import { fetchProducts } from "../../services/admin";
 
 interface Product {
@@ -9,12 +17,31 @@ interface Product {
   nom_lolly: string;
 }
 
+const PAGE_SIZE = 50;
+
 const ProductsTab: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const loadPage = async (pageIndex: number) => {
+    setLoading(true);
+    const from = pageIndex * PAGE_SIZE;
+    const to = from + PAGE_SIZE - 1;
+    const { data } = await fetchProducts(from, to);
+    setProducts((prev) => [...prev, ...(data || [])]);
+    setLoading(false);
+  };
 
   useEffect(() => {
-    fetchProducts().then(({ data }) => setProducts(data || []));
+    loadPage(0);
   }, []);
+
+  const loadMore = () => {
+    const next = page + 1;
+    setPage(next);
+    loadPage(next);
+  };
 
   return (
     <Card>
@@ -38,6 +65,12 @@ const ProductsTab: React.FC = () => {
             ))}
           </TableBody>
         </Table>
+        {loading && <div className="mt-4">Chargement...</div>}
+        <div className="mt-4 flex justify-center">
+          <Button onClick={loadMore} disabled={loading} variant="outline">
+            Charger plus
+          </Button>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/services/admin.ts
+++ b/src/services/admin.ts
@@ -1,54 +1,30 @@
-import { supabase } from '../lib/supabaseClient';
+import { supabase } from "../lib/supabaseClient";
 
-export const fetchUsers = () =>
-  supabase
-    .from('users')
-    .select(
-      'id, prenom, nom, email, role, telephone, whatsapp, date_naissance, adresse, code_client, created_at',
-    )
-    .order('created_at', { ascending: false })
-    .range(0, 99);
+const PAGE_SIZE = 50;
 
-export const fetchProducts = () =>
+export const fetchUsers = (from = 0, to = from + PAGE_SIZE - 1) =>
   supabase
-    .from('products')
-    .select(`
-      id,
-      code_produit,
-      nom_lolly,
-      nom_parfum_inspire,
-      marque_inspire,
-      active,
-      image_url,
-      genre,
-      saison,
-      famille_olfactive,
-      note_tete,
-      note_coeur,
-      note_fond,
-      description,
-      product_variants(
-        id,
-        contenance,
-        unite,
-        prix,
-        stock_actuel,
-        ref_complete,
-        actif
-      )
-    `)
-    .range(0, 99);
+    .from("users")
+    .select("id, prenom, nom, email")
+    .order("created_at", { ascending: false })
+    .range(from, to);
 
-export const fetchPromotions = () =>
+export const fetchProducts = (from = 0, to = from + PAGE_SIZE - 1) =>
   supabase
-    .from('promotions')
-    .select('id, nom, pourcentage_reduction, description, date_debut, date_fin, active')
-    .order('date_debut', { ascending: false })
-    .range(0, 99);
+    .from("products")
+    .select("id, code_produit, nom_lolly")
+    .range(from, to);
 
-export const fetchOrders = () =>
+export const fetchPromotions = (from = 0, to = from + PAGE_SIZE - 1) =>
   supabase
-    .from('orders')
+    .from("promotions")
+    .select("id, nom, pourcentage_reduction")
+    .order("date_debut", { ascending: false })
+    .range(from, to);
+
+export const fetchOrders = (from = 0, to = from + PAGE_SIZE - 1) =>
+  supabase
+    .from("orders")
     .select(`
       id,
       created_at,
@@ -67,5 +43,5 @@ export const fetchOrders = () =>
         )
       )
     `)
-    .order('created_at', { ascending: false })
-    .range(0, 99);
+    .order("created_at", { ascending: false })
+    .range(from, to);


### PR DESCRIPTION
## Summary
- trim admin fetches to essential fields and add pagination support
- paginate Products tab and show loading indicator with 'load more' button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a11d99c8a0832b9a1874e1aa0af13a