### PR TITLE
Optimize Supabase image URLs and lazy loading

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -59,6 +59,7 @@ import {
 import PerfumeCatalog from "./catalog/PerfumeCatalog";
 import PerfumeDetail from "./catalog/PerfumeDetail";
 import { supabase } from "../lib/supabaseClient";
+import { getPublicImageUrl } from "../lib/imageUtils";
 
 const AdminSpace = () => {
   const { register } = useAuth();
@@ -241,7 +242,9 @@ const AdminSpace = () => {
                 0,
               ) || 0,
             active: product.active,
-            imageURL: product.image_url,
+            imageURL: product.image_url
+              ? getPublicImageUrl(product.image_url)
+              : '',
             genre: product.genre,
             saison: product.saison,
             familleOlfactive: product.famille_olfactive,
@@ -4306,6 +4309,8 @@ const AdminSpace = () => {
                           "https://images.unsplash.com/photo-1594035910387-fea47794261f?w=400&q=80"
                         }
                         alt={selectedProduct.name}
+                        loading="lazy"
+                        decoding="async"
                         className="w-full h-48 object-cover rounded"
                         key={`preview-${selectedProduct.id}-${selectedProduct.lastModified || Date.now()}`}
                       />
@@ -4473,6 +4478,8 @@ const AdminSpace = () => {
                           "https://images.unsplash.com/photo-1594035910387-fea47794261f?w=400&q=80"
                         }
                         alt={selectedProduct.name}
+                        loading="lazy"
+                        decoding="async"
                         className="w-full h-48 object-cover rounded border"
                       />
                       <Input

--- a/src/components/ClientSpace.tsx
+++ b/src/components/ClientSpace.tsx
@@ -279,6 +279,8 @@ const ClientSpace = () => {
             <img
               src="/logo-lolly.png"
               alt="Lolly"
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-contain"
             />
           </div>
@@ -458,6 +460,8 @@ const ClientSpace = () => {
                           <img
                             src={favorite.imageURL}
                             alt={favorite.nomLolly}
+                            loading="lazy"
+                            decoding="async"
                             className="w-full h-32 object-cover rounded mb-2"
                           />
                           <h4 className="font-medium text-[#805050] mb-1">
@@ -753,6 +757,8 @@ const ClientSpace = () => {
                               <img
                                 src={favorite.imageURL}
                                 alt={favorite.nomLolly}
+                                loading="lazy"
+                                decoding="async"
                                 className="w-full h-32 object-cover rounded mb-2"
                               />
                               <h4 className="font-medium text-[#805050] mb-1">

--- a/src/components/ConseillerSpace.tsx
+++ b/src/components/ConseillerSpace.tsx
@@ -674,6 +674,8 @@ const ConseillerSpace = () => {
                               <img
                                 src={favorite.imageURL}
                                 alt={favorite.nomLolly}
+                                loading="lazy"
+                                decoding="async"
                                 className="w-16 h-16 object-cover rounded"
                               />
                               <div className="flex-1 min-w-0">

--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -19,6 +19,8 @@ const HomeLayout = ({ children = null }: HomeLayoutProps) => {
           <img
             src="/logo-lolly.png"
             alt="Lolly"
+            loading="lazy"
+            decoding="async"
             className="w-full h-full object-contain"
           />
         </div>

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -234,6 +234,8 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
                   <img
                     src={item.imageURL}
                     alt={item.nomLolly}
+                    loading="lazy"
+                    decoding="async"
                     className="w-16 h-16 object-cover rounded flex-shrink-0"
                   />
                   <div className="flex-1 min-w-0">

--- a/src/components/catalog/PerfumeCard.tsx
+++ b/src/components/catalog/PerfumeCard.tsx
@@ -100,6 +100,8 @@ const PerfumeCard = ({
         <img
           src={imageURL}
           alt={nomLolly}
+          loading="lazy"
+          decoding="async"
           className="w-full h-full object-cover transition-transform duration-500 hover:scale-105"
         />
         <div className="absolute top-2 left-2 bg-[#CE8F8A] text-white text-xs px-2 py-1 rounded">

--- a/src/components/catalog/PerfumeCatalog.tsx
+++ b/src/components/catalog/PerfumeCatalog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/select";
 import PerfumeCard from "./PerfumeCard";
 import { supabase } from "@/lib/supabaseClient";
+import { getPublicImageUrl } from "@/lib/imageUtils";
 
 interface PerfumeType {
   codeProduit: string;
@@ -82,9 +83,9 @@ const PerfumeCatalog = ({
             (product.saison as "été" | "hiver" | "toutes saisons") ||
             "toutes saisons",
           familleOlfactive: product.famille_olfactive || "Oriental",
-          imageURL:
-            product.image_url ||
-            "https://images.unsplash.com/photo-1594035910387-fea47794261f?w=400&q=80",
+          imageURL: product.image_url
+            ? getPublicImageUrl(product.image_url)
+            : "https://images.unsplash.com/photo-1594035910387-fea47794261f?w=400&q=80",
           active: product.active,
         }));
 

--- a/src/components/catalog/PerfumeDetail.tsx
+++ b/src/components/catalog/PerfumeDetail.tsx
@@ -16,6 +16,7 @@ import { useFavorites } from "@/contexts/FavoritesContext";
 import { useAuth } from "@/contexts/AuthContext";
 import CartDialog from "@/components/cart/CartDialog";
 import { supabase } from "@/lib/supabaseClient";
+import { getPublicImageUrl } from "@/lib/imageUtils";
 
 interface PerfumeSummary {
   codeProduit: string;
@@ -145,7 +146,9 @@ const PerfumeDetail: React.FC<PerfumeDetailProps> = ({
           noteCoeur: data.note_coeur || [],
           noteFond: data.note_fond || [],
           description: data.description || "",
-          imageURL: data.image_url || prev.imageURL,
+          imageURL: data.image_url
+            ? getPublicImageUrl(data.image_url)
+            : prev.imageURL,
           contenances:
             data.product_variants?.map((v: any) => ({
               refComplete: v.ref_complete,
@@ -271,6 +274,8 @@ const PerfumeDetail: React.FC<PerfumeDetailProps> = ({
                 key={imageKey}
                 src={imageUrlWithCacheBust}
                 alt={currentPerfume.nomLolly}
+                loading="lazy"
+                decoding="async"
                 className="w-full h-full object-cover rounded-xl"
                 onError={(e) => {
                   // Fallback to original URL if cache-busted version fails

--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -1,0 +1,23 @@
+import { supabase } from './supabaseClient';
+
+/**
+ * Generate a public URL for an image stored in Supabase Storage
+ * with basic transformation for size and quality.
+ *
+ * @param path Path to the image inside the storage bucket.
+ * If a full URL is provided, it will be returned as-is.
+ */
+export function getPublicImageUrl(path: string): string {
+  if (!path) return '';
+  if (path.startsWith('http')) return path;
+
+  const [bucket, ...fileParts] = path.split('/');
+  const filePath = fileParts.join('/');
+
+  const { data } = supabase.storage.from(bucket).getPublicUrl(filePath, {
+    transform: { width: 400, quality: 70 },
+  });
+
+  return data.publicUrl;
+}
+

--- a/src/stories/aspect-ratio.stories.tsx
+++ b/src/stories/aspect-ratio.stories.tsx
@@ -16,6 +16,8 @@ export const Base = {
       <img
         src="https://images.unsplash.com/photo-1576075796033-848c2a5f3696?w=800&dpr=2&q=80"
         alt="Photo by Alvaro Pinot"
+        loading="lazy"
+        decoding="async"
         className="rounded-md object-cover"
       />
     </AspectRatio>


### PR DESCRIPTION
## Summary
- Generate public image URLs from Supabase Storage with transformation options
- Lazy-load images with async decoding across components for better performance

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: eslint not found; install attempt forbidden)*
- `npm run build` *(warn: TypeScript property errors but build completed)*

------
https://chatgpt.com/codex/tasks/task_e_68a334a1abc4832b9765d2116cfc1ed5