### PR TITLE
feat: lazy load perfume detail

### DIFF
--- a/src/components/ClientSpace.tsx
+++ b/src/components/ClientSpace.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, Suspense } from "react";
 import { motion } from "framer-motion";
 import PerfumeCatalog from "./catalog/PerfumeCatalog";
-import PerfumeDetail from "./catalog/PerfumeDetail";
 import { Button } from "./ui/button";
 import {
   ShoppingBag,
@@ -20,6 +19,8 @@ import LoginDialog from "./auth/LoginDialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
+
+const PerfumeDetail = React.lazy(() => import("./catalog/PerfumeDetail"));
 
 // Order History Component
 const OrderHistory = () => {
@@ -379,7 +380,9 @@ const ClientSpace = () => {
                 <ArrowLeft className="w-4 h-4 mr-2" />
                 Retour au catalogue
               </Button>
-              <PerfumeDetail perfume={selectedPerfume} />
+              <Suspense fallback={<div>Chargement...</div>}>
+                <PerfumeDetail perfume={selectedPerfume} />
+              </Suspense>
             </div>
           ) : showFavorites ? (
             <div>


### PR DESCRIPTION
## Summary
- lazy-load `PerfumeDetail` using `React.lazy`
- wrap `PerfumeDetail` display in `Suspense` with fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint: not found; install attempt forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3379b2a1c832b860aa3ac66c38031