### PR TITLE
Use adresse column for user profile

### DIFF
--- a/src/features/auth/signIn.ts
+++ b/src/features/auth/signIn.ts
@@ -35,10 +35,10 @@ export async function handleSignIn(email: string, password: string) {
     const { error: insErr } = await supabase.from('users').insert({
       id: user.id,
       email: user.email ?? '',   // ← important si email est NOT NULL / UNIQUE
-      // anglais (laisse null si ta table les accepte)
+      // valeurs par défaut pour toutes les colonnes
       first_name: null,
       last_name:  null,
-      address:    null,
+      adresse:    null,
       phone:      null,
       whatsapp:   null,
       birth_date: null,

--- a/src/features/auth/signUp.ts
+++ b/src/features/auth/signUp.ts
@@ -47,7 +47,7 @@ export async function handleSignUp(p: SignUpPayload) {
     // valeurs issues du formulaire
     first_name: p.prenom ?? null,
     last_name:  p.nom ?? null,
-    address:    p.adresse ?? null,
+    adresse:    p.adresse ?? null,
     phone:      p.telephone ?? null,
     whatsapp:   p.whatsapp ?? null,
     birth_date: p.dateNaissance ?? null,


### PR DESCRIPTION
## Summary
- insert user `adresse` instead of `address` during sign up and sign in

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a33dab93f4832ba3e45197c65e1641