### PR TITLE
feat: decrement inventory on orders

### DIFF
--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -108,6 +108,14 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
         .insert(orderItems);
       if (itemsError) throw itemsError;
 
+      // Decrement stock for each ordered item
+      for (const oi of orderItems) {
+        await supabase.rpc("trg_decrement_stock", {
+          product_variant_id: oi.product_variant_id,
+          quantity: oi.quantity,
+        });
+      }
+
       // 4. Store order locally
       const orderData = {
         id: orderId,

--- a/supabase/migrations/20250815000000_decrement_stock_after_order.sql
+++ b/supabase/migrations/20250815000000_decrement_stock_after_order.sql
@@ -1,0 +1,16 @@
+-- Function called by trigger to decrement stock
+create or replace function public.trg_decrement_stock()
+returns trigger as $$
+begin
+  update product_variants
+    set stock_actuel = stock_actuel - new.quantity
+  where id = new.product_variant_id;
+  return new;
+end;
+$$ language plpgsql;
+
+-- Trigger to decrement stock after inserting order items
+drop trigger if exists trg_decrement_stock on public.order_items;
+create trigger trg_decrement_stock
+  after insert on public.order_items
+  for each row execute function public.trg_decrement_stock();


### PR DESCRIPTION
## Summary
- create database trigger to decrement stock on order item inserts
- invoke RPC to update stock after cart checkout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a359a8ec80832b96e07e369e4efc5a