### PR TITLE
fix: handle missing sale amounts in export

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -486,7 +486,10 @@ const AdminSpace = () => {
       });
 
       filteredSales.forEach((sale) => {
-        rows += `"${sale.date}","${sale.client}","${sale.codeClient}","${sale.product}","${sale.codeArticle}","Yves Saint Laurent","${sale.amount.toFixed(3)}","${sale.conseillere}"\n`;
+        const amount = Number.isFinite(sale.amount)
+          ? sale.amount.toFixed(3)
+          : "0.000";
+        rows += `"${sale.date}","${sale.client}","${sale.codeClient}","${sale.product}","${sale.codeArticle}","Yves Saint Laurent","${amount}","${sale.conseillere}"\n`;
       });
     } else if (type === "clients") {
       headers =


### PR DESCRIPTION
## Summary
- guard against invalid sale amounts when exporting sales

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`
- manual Node script to export sales with missing amounts


------
https://chatgpt.com/codex/tasks/task_e_68a3643cba18832bb3eccb29432ac70d