### PR TITLE
Track and export sale quantities

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -382,6 +382,7 @@ const AdminSpace = () => {
                 item.product_variants?.products?.nom_lolly ??
                 "Produit inconnu",
               codeArticle: item.product_variants?.ref_complete ?? "N/A",
+              quantity: item.quantity,
               amount: item.total_price,
               conseillere:
                 order.conseillere &&
@@ -450,6 +451,7 @@ const AdminSpace = () => {
           codeClient: e.detail.codeClient,
           product: p.product,
           codeArticle: p.codeArticle,
+          quantity: p.quantity,
           amount: p.amount,
           conseillere: p.conseillere || "N/A",
         }));
@@ -458,6 +460,7 @@ const AdminSpace = () => {
         const sale = {
           ...e.detail,
           id: e.detail?.id ?? `${Date.now()}`,
+          quantity: e.detail.quantity,
         };
         setOrders((prev) => [sale, ...prev]);
       }
@@ -487,7 +490,7 @@ const AdminSpace = () => {
 
       if (type === "sales") {
         headers =
-          "Date,Client,Code Client,Produit,Code Article,Marque Inspirée,Montant TND,Conseillère\n";
+          "Date,Client,Code Client,Produit,Code Article,Quantité,Marque Inspirée,Montant TND,Conseillère\n";
         const filteredSales = orders.filter((sale) => {
           if (!dateFilter.start || !dateFilter.end) return true;
           const saleDate = new Date(sale.date);
@@ -504,7 +507,7 @@ const AdminSpace = () => {
           const amount = Number.isFinite(sale.amount)
             ? sale.amount.toFixed(3)
             : "0.000";
-          rows += `"${sale.date}","${sale.client}","${sale.codeClient}","${sale.product}","${sale.codeArticle}","Yves Saint Laurent","${amount}","${sale.conseillere}"\n`;
+          rows += `"${sale.date}","${sale.client}","${sale.codeClient}","${sale.product}","${sale.codeArticle}","${sale.quantity}","Yves Saint Laurent","${amount}","${sale.conseillere}"\n`;
         });
       } else if (type === "clients") {
         headers =
@@ -3348,6 +3351,7 @@ const AdminSpace = () => {
                           <TableHead>Code Client</TableHead>
                           <TableHead>Produit</TableHead>
                           <TableHead>Code Article</TableHead>
+                          <TableHead>Quantité</TableHead>
                           <TableHead>Marque Inspirée</TableHead>
                           <TableHead>Montant (TND)</TableHead>
                           <TableHead>Conseillère</TableHead>
@@ -3361,6 +3365,7 @@ const AdminSpace = () => {
                             <TableCell>{sale.codeClient}</TableCell>
                             <TableCell>{sale.product}</TableCell>
                             <TableCell>{sale.codeArticle}</TableCell>
+                            <TableCell>{sale.quantity}</TableCell>
                             <TableCell>Yves Saint Laurent</TableCell>
                             <TableCell>{sale.amount.toFixed(3)} TND</TableCell>
                             <TableCell>{sale.conseillere}</TableCell>

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -148,6 +148,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
             codeClient: orderData.codeClient,
             product: item.product,
             codeArticle: item.codeArticle,
+            quantity: item.quantity,
             amount: item.amount,
             conseillere: "N/A",
           },


### PR DESCRIPTION
## Summary
- track item quantity when loading sales and receiving new sale events
- display quantity in admin sales report and include it in CSV export
- include quantity in cart dialog's sale event payload

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a3808939ec832ba995919b09007fa8