### PR TITLE
feat: align Supabase env vars with Vercel

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,8 @@
 // src/lib/supabaseClient.ts
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const supabaseUrl = import.meta.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
 
 // IMPORTANT : n'utilise jamais la service_role key côté frontend.
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_` prefixed Supabase env vars for frontend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build` *(fails: Property 'codeArticle' does not exist on type '{}')*

------
https://chatgpt.com/codex/tasks/task_e_68a3a4a3e34c832bad143cc451ed5fb7