### PR TITLE
feat: expose NEXT_PUBLIC env vars

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { tempo } from "tempo-devtools/dist/vite";
 export default defineConfig({
   base: "/",
   cacheDir: "node_modules/.vite-cache",
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
   optimizeDeps: {
     entries: ["src/main.tsx", "src/tempobook/**/*"],
     force: true,


### PR DESCRIPTION
## Summary
- allow Vite to load `NEXT_PUBLIC_*` environment variables via `envPrefix`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a8ed7648832bbded1d7ebfdef0f0