### PR TITLE
refactor: use alias for supabase client

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -59,7 +59,7 @@ import {
 } from "lucide-react";
 import PerfumeCatalog from "./catalog/PerfumeCatalog";
 import PerfumeDetail from "./catalog/PerfumeDetail";
-import { supabase } from "../lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 
 const AdminSpace = () => {
   const { register } = useAuth();

--- a/src/features/auth/signIn.ts
+++ b/src/features/auth/signIn.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '@/lib/supabaseClient';
 
 /**
  * Connexion puis "ensure profile":

--- a/src/features/auth/signUp.ts
+++ b/src/features/auth/signUp.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '@/lib/supabaseClient';
 
 export type SignUpPayload = {
   email: string;


### PR DESCRIPTION
## Summary
- use root alias for supabase client imports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b2a7ed9c832bab0b4176659c923d