### PR TITLE
Include user role in auth context

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,10 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import type { Session, User } from '@supabase/supabase-js';
+import type { Session, User as SupabaseUser } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabaseClient';
+
+interface User extends SupabaseUser {
+  role?: string;
+}
 
 type AuthCtx = {
   user: User | null;
@@ -27,23 +31,37 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const getUserWithRole = async (u: SupabaseUser | null): Promise<User | null> => {
+    if (!u) return null;
+    let role = (u.user_metadata as any)?.role as string | undefined;
+    if (!role) {
+      const { data } = await supabase
+        .from('users')
+        .select('role')
+        .eq('id', u.id)
+        .single();
+      role = data?.role;
+    }
+    return { ...u, role } as User;
+  };
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code') ?? params.get('token');
     if (code) {
-      supabase.auth.exchangeCodeForSession(code).then(({ data }) => {
+      supabase.auth.exchangeCodeForSession(code).then(async ({ data }) => {
         if (data?.session) {
           setSession(data.session);
-          setUser(data.session.user);
+          setUser(await getUserWithRole(data.session.user));
           window.history.replaceState({}, '', window.location.pathname);
         }
       });
     } else if (window.location.hash.includes('access_token')) {
       // getSessionFromUrl is not typed in our Supabase client, so cast to any
-      (supabase.auth as any).getSessionFromUrl().then(({ data }: { data: { session: Session | null } }) => {
+      (supabase.auth as any).getSessionFromUrl().then(async ({ data }: { data: { session: Session | null } }) => {
         if (data?.session) {
           setSession(data.session);
-          setUser(data.session.user);
+          setUser(await getUserWithRole(data.session.user));
           window.history.replaceState({}, '', window.location.pathname);
         }
       });
@@ -55,13 +73,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const { data } = await supabase.auth.getSession();
       if (!mounted) return;
       setSession(data.session ?? null);
-      setUser(data.session?.user ?? null);
+      setUser(await getUserWithRole(data.session?.user ?? null));
       setLoading(false);
     })();
 
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, newSession) => {
+    const { data: sub } = supabase.auth.onAuthStateChange(async (_event, newSession) => {
       setSession(newSession);
-      setUser(newSession?.user ?? null);
+      setUser(await getUserWithRole(newSession?.user ?? null));
       window.dispatchEvent(new CustomEvent('auth:changed'));
     });
 
@@ -83,7 +101,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     refresh: async () => {
       const { data } = await supabase.auth.getSession();
       setSession(data.session ?? null);
-      setUser(data.session?.user ?? null);
+      setUser(await getUserWithRole(data.session?.user ?? null));
     },
   }), [user, session, loading]);
 


### PR DESCRIPTION
## Summary
- augment auth context user type with a role field
- load role from user metadata or `public.users` table when sessions update

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Property 'telephone' does not exist on type 'User', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a3b78cc488832bbd9e7f374789f62e