### PR TITLE
Handle user roles during sign in

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -46,9 +46,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .select('role')
         .eq('id', u.id)
         .single();
-      role = data?.role;
+      role = data?.role ?? undefined;
     }
-    return { ...u, role } as User;
+    return { ...u, role: role ?? 'client' } as User;
   };
 
   useEffect(() => {

--- a/src/features/auth/signIn.ts
+++ b/src/features/auth/signIn.ts
@@ -35,6 +35,8 @@ export async function handleSignIn(email: string, password: string) {
     const { error: insErr } = await supabase.from('users').insert({
       id: user.id,
       email: user.email ?? '',   // ← important si email est NOT NULL / UNIQUE
+      // valeur par défaut du rôle (admin forcé pour l'email spécifique)
+      role: user.email === 'admin@lecompasolfactif.com' ? 'admin' : 'client',
       // valeurs par défaut pour toutes les colonnes
       first_name: null,
       last_name:  null,
@@ -47,13 +49,25 @@ export async function handleSignIn(email: string, password: string) {
       nom:    '',
     });
     if (insErr) return { ok: false, step: 'insertProfile', error: insErr.message };
-  } else if (!profile.email && user.email) {
-    // ancien profil sans email → on le complète
-    const { error: updErr } = await supabase
-      .from('users')
-      .update({ email: user.email })
-      .eq('id', user.id);
-    if (updErr) return { ok: false, step: 'updateEmail', error: updErr.message };
+  } else {
+    // profil existant mais complétion possible
+    if (!profile.email && user.email) {
+      // ancien profil sans email → on le complète
+      const { error: updErr } = await supabase
+        .from('users')
+        .update({ email: user.email })
+        .eq('id', user.id);
+      if (updErr) return { ok: false, step: 'updateEmail', error: updErr.message };
+    }
+    if (!profile.role) {
+      const { error: updRoleErr } = await supabase
+        .from('users')
+        .update({
+          role: user.email === 'admin@lecompasolfactif.com' ? 'admin' : 'client',
+        })
+        .eq('id', user.id);
+      if (updRoleErr) return { ok: false, step: 'updateRole', error: updRoleErr.message };
+    }
   }
 
   return { ok: true, user };


### PR DESCRIPTION
## Summary
- set default role when creating or completing user profiles
- ensure `AuthContext` always exposes a role for logged in users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3bea92144832b9e724fabb1c7166e