### PR TITLE
feat: verify client login without touching global session

### DIFF
--- a/src/components/ClientLoginDialog.tsx
+++ b/src/components/ClientLoginDialog.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
+import { verifyClientCredentials } from "@/services/auth/verifyClientCredentials";
 
 interface ClientLoginDialogProps {
   open: boolean;
@@ -34,7 +35,7 @@ const ClientLoginDialog: React.FC<ClientLoginDialogProps> = ({
   title = "Identification Client",
   description = "Identifiez le client pour associer le panier à son compte",
 }) => {
-  const { login, register, user } = useAuth();
+  const { register, user } = useAuth();
   const [loginData, setLoginData] = useState({ email: "", password: "" });
   const [registerData, setRegisterData] = useState<{
     email: string;
@@ -68,9 +69,12 @@ const ClientLoginDialog: React.FC<ClientLoginDialogProps> = ({
     setError("");
 
     try {
-      const success = await login(loginData.email, loginData.password);
-      if (success) {
-        onSuccess?.(user);
+      const clientData = await verifyClientCredentials(
+        loginData.email,
+        loginData.password,
+      );
+      if (clientData) {
+        onSuccess?.(clientData);
         onOpenChange(false);
       } else {
         setError("Email ou mot de passe incorrect");

--- a/src/services/auth/verifyClientCredentials.ts
+++ b/src/services/auth/verifyClientCredentials.ts
@@ -1,0 +1,52 @@
+import { createClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+/**
+ * Vérifie les identifiants d'un client sans toucher à l'instance Supabase globale.
+ * Crée une instance éphémère avec persistSession: false, effectue la connexion,
+ * récupère le profil éventuel puis se déconnecte pour nettoyer la session.
+ */
+export async function verifyClientCredentials(
+  email: string,
+  password: string,
+) {
+  const client = createClient(supabaseUrl, supabaseAnon, {
+    auth: { persistSession: false },
+  });
+
+  try {
+    const { data, error } = await client.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error || !data?.user) {
+      logger.error("Client credential verification failed", error);
+      return null;
+    }
+
+    const { data: profile, error: profileError } = await client
+      .from("users")
+      .select("*")
+      .eq("id", data.user.id)
+      .single();
+
+    if (profileError) {
+      logger.error("Failed to fetch client profile", profileError);
+    }
+
+    await client.auth.signOut();
+
+    return {
+      user: data.user,
+      profile: profile ?? null,
+      email: data.user.email,
+      codeClient: profile?.code_client ?? null,
+    };
+  } catch (err) {
+    logger.error("Unexpected client verification error", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `verifyClientCredentials` helper using an ephemeral Supabase client
- use the helper in `ClientLoginDialog` and forward `clientData` on success

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build` *(TypeScript errors: Property 'telephone' does not exist on type 'User', Property 'whatsapp' does not exist on type 'User', Property 'adresse' does not exist on type 'User', Property 'prenom' does not exist on type 'User', Property 'nom' does not exist on type 'User')*

------
https://chatgpt.com/codex/tasks/task_e_68a3c231208c832b9643081dc91ecde6