### PR TITLE
Handle data load failures in AdminSpace with error UI and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build-no-errors": "tsc ; vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "types:supabase": "npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts"
+    "types:supabase": "npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fontsource/montserrat": "^5.2.6",
@@ -72,6 +73,10 @@
     "tailwindcss": "3.4.1",
     "tempo-devtools": "^2.0.109",
     "typescript": "^5.8.2",
-    "vite": "^6.2.3"
+    "vite": "^6.2.3",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -107,6 +107,7 @@ const AdminSpace = () => {
   // State for products from Supabase
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [errorState, setErrorState] = useState<string | null>(null);
 
   const [users, setUsers] = useState([]);
   const [promotions, setPromotions] = useState([]);
@@ -129,6 +130,7 @@ const AdminSpace = () => {
 
     try {
       setLoading(true);
+      setErrorState(null);
 
       // STEP 1: Load users with comprehensive RLS error handling
       console.log("👥 Loading users from Supabase...");
@@ -189,6 +191,9 @@ const AdminSpace = () => {
           );
         }
         setUsers([]);
+        setErrorState("Erreur lors du chargement des utilisateurs");
+        setLoading(false);
+        return;
       } else {
         // Always process the data, even if it's an empty array
         const userData = usersData || [];
@@ -238,6 +243,9 @@ const AdminSpace = () => {
 
         if (productsError) {
           console.error("❌ Products error:", productsError);
+          setErrorState("Erreur lors du chargement des produits");
+          setLoading(false);
+          return;
         } else {
           const formattedProducts = (productsData || []).map((product) => ({
             id: product.id,
@@ -274,9 +282,12 @@ const AdminSpace = () => {
           setProducts(formattedProducts);
           console.log("✅ Products loaded:", formattedProducts.length);
         }
-      } catch (err) {
-        console.error("❌ Products loading failed:", err);
-      }
+        } catch (err) {
+          console.error("❌ Products loading failed:", err);
+          setErrorState("Erreur lors du chargement des produits");
+          setLoading(false);
+          return;
+        }
 
       // STEP 4: Load promotions (simplified)
       console.log("🎯 Loading promotions...");
@@ -287,13 +298,19 @@ const AdminSpace = () => {
 
         if (promotionsError) {
           console.error("❌ Promotions error:", promotionsError);
+          setErrorState("Erreur lors du chargement des promotions");
+          setLoading(false);
+          return;
         } else {
           setPromotions(promotionsData || []);
           console.log("✅ Promotions loaded:", (promotionsData || []).length);
         }
-      } catch (err) {
-        console.error("❌ Promotions loading failed:", err);
-      }
+        } catch (err) {
+          console.error("❌ Promotions loading failed:", err);
+          setErrorState("Erreur lors du chargement des promotions");
+          setLoading(false);
+          return;
+        }
 
       // STEP 5: Load orders (simplified)
       console.log("📋 Loading orders...");
@@ -360,6 +377,9 @@ const AdminSpace = () => {
             );
           }
           setOrders([]);
+          setErrorState("Erreur lors du chargement des commandes");
+          setLoading(false);
+          return;
         } else {
           const formattedOrders = (ordersData || []).flatMap((order) =>
             (order.order_items || []).map((item) => ({
@@ -409,12 +429,16 @@ const AdminSpace = () => {
         }
       } catch (err) {
         console.error("❌ Orders loading failed:", err);
+        setErrorState("Erreur lors du chargement des commandes");
+        setLoading(false);
+        return;
       }
     } catch (error) {
       console.error("💥 RADICAL RELOAD FAILED:", error);
       alert(
         "❌ Erreur critique lors du chargement des données: " + error.message,
       );
+      setErrorState("Erreur critique lors du chargement des données");
     } finally {
       setLoading(false);
       console.log("🏁 RADICAL RELOAD COMPLETED");
@@ -2621,6 +2645,18 @@ const AdminSpace = () => {
         }}
         hideRegistration={true}
       />
+    );
+  }
+
+  if (errorState) {
+    return (
+      <div className="min-h-screen bg-[#FBF0E9] flex items-center justify-center">
+        <div className="text-center">
+          <AlertTriangle className="mx-auto mb-4 h-16 w-16 text-red-500" />
+          <p className="text-[#805050] font-montserrat mb-4">{errorState}</p>
+          <Button onClick={() => loadData()}>Réessayer</Button>
+        </div>
+      </div>
     );
   }
 

--- a/src/components/__tests__/AdminSpace.test.tsx
+++ b/src/components/__tests__/AdminSpace.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import AdminSpace from '../AdminSpace';
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { email: 'admin@lecompasolfactif.com', role: 'admin' },
+    isAuthenticated: true,
+    register: vi.fn(),
+  }),
+}));
+
+vi.mock('../auth/LoginDialog', () => ({ default: () => null }));
+vi.mock('../HomeLayout', () => ({ default: ({ children }: any) => <div>{children}</div> }));
+vi.mock('../ui/button', () => ({ Button: ({ children, ...props }: any) => <button {...props}>{children}</button> }));
+vi.mock('../ui/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        order: async () => ({ data: null, error: { message: 'fail' } }),
+      }),
+    }),
+  },
+}));
+
+test('renders error message when data loading fails', async () => {
+  render(<AdminSpace />);
+  const message = await screen.findByText('Erreur lors du chargement des utilisateurs');
+  expect(message).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByText(/Chargement des données/)).not.toBeInTheDocument();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,4 +88,8 @@ export default defineConfig({
     "process.env.NODE_ENV": JSON.stringify("development"),
   },
   clearScreen: false,
+  test: {
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+  },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,6 @@
+import '@testing-library/jest-dom';
+
+// Provide mock implementations for browser APIs used in the app
+globalThis.window ??= globalThis;
+
+export {};


### PR DESCRIPTION
## Summary
- Add `errorState` to AdminSpace and update `loadData` to set it on fetch failures while ensuring `setLoading(false)` always fires.
- Render an accessible error message with retry button when data loading fails instead of showing the spinner indefinitely.
- Configure Vitest and add regression test covering failed fetch behaviour.

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cad98c30832bb1daae8eb9aa9ac2