### PR TITLE
feat(api): handle CORS in create-user endpoint

### DIFF
--- a/api/admin/create-user.js
+++ b/api/admin/create-user.js
@@ -7,6 +7,19 @@ const {
 } = process.env;
 
 export default async function handler(req, res) {
+  const origin = process.env.ALLOWED_ORIGIN || '*';
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization'
+  );
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
   try {
     if (req.method !== 'POST') {
       res.status(405).json({ error: 'Method Not Allowed' });


### PR DESCRIPTION
## Summary
- allow cross-origin requests for admin user creation endpoint
- handle OPTIONS preflight requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3cd5e2468832b9703db5723100491