### PR TITLE
chore: use server supabase env vars

### DIFF
--- a/api/admin/create-user.js
+++ b/api/admin/create-user.js
@@ -1,8 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 
 const {
-  NEXT_PUBLIC_SUPABASE_URL: SUPABASE_URL,
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: SUPABASE_ANON_KEY,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
   SUPABASE_SERVICE_ROLE_KEY
 } = process.env;
 


### PR DESCRIPTION
## Summary
- use server-side Supabase env vars in `create-user` API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d523ff60832b8a08d9151d2b18f0