### PR TITLE
Simplify admin authentication flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build-no-errors": "tsc ; vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "types:supabase": "npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts"
+    "types:supabase": "npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts",
+    "test": "vitest run --environment jsdom"
   },
   "dependencies": {
     "@fontsource/montserrat": "^5.2.6",
@@ -72,6 +73,9 @@
     "tailwindcss": "3.4.1",
     "tempo-devtools": "^2.0.109",
     "typescript": "^5.8.2",
-    "vite": "^6.2.3"
+    "vite": "^6.2.3",
+    "vitest": "^2.1.3",
+    "@testing-library/react": "^15.0.3",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/src/components/AdminSpace.test.tsx
+++ b/src/components/AdminSpace.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import "@testing-library/jest-dom";
+import AdminSpace from "./AdminSpace";
+
+// Mock Auth context
+const mockAuthState: any = {
+  user: null,
+  isAuthenticated: false,
+  signOut: vi.fn(),
+};
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+// Mock LoginDialog
+vi.mock("./auth/LoginDialog", () => ({
+  default: () => <div data-testid="login-dialog">Login</div>,
+}));
+
+// Mock supabase client
+vi.mock("@/lib/supabaseClient", () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        order: () => Promise.resolve({ data: [], error: null }),
+        eq: () => ({ single: () => Promise.resolve({ data: null, error: null }) }),
+        single: () => Promise.resolve({ data: null, error: null }),
+      }),
+    }),
+  },
+}));
+
+// Mock toast hook
+vi.mock("./ui/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe("AdminSpace", () => {
+  test("shows login dialog when not authenticated", () => {
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    render(<AdminSpace />);
+    expect(screen.getByTestId("login-dialog")).toBeInTheDocument();
+  });
+
+  test("shows login dialog when authenticated but not admin", () => {
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = { role: "client" };
+    render(<AdminSpace />);
+    expect(screen.getByTestId("login-dialog")).toBeInTheDocument();
+  });
+
+  test("shows admin space after successful admin login", async () => {
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    const { rerender } = render(<AdminSpace />);
+    expect(screen.getByTestId("login-dialog")).toBeInTheDocument();
+
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = { role: "admin" };
+    rerender(<AdminSpace />);
+    expect(await screen.findByText(/Espace Administration/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -62,13 +62,10 @@ import PerfumeDetail from "./catalog/PerfumeDetail";
 import { supabase } from "@/lib/supabaseClient";
 
 const AdminSpace = () => {
-  const { register } = useAuth();
   const { toast } = useToast();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedProduct, setSelectedProduct] = useState(null);
   const [dateFilter, setDateFilter] = useState({ start: "", end: "" });
-  const [showLogin, setShowLogin] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [showNewProduct, setShowNewProduct] = useState(false);
   const [noteTete, setNoteTete] = useState("");
   const [noteCoeur, setNoteCoeur] = useState("");
@@ -422,11 +419,11 @@ const AdminSpace = () => {
   };
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (authIsAuthenticated && authUser?.role === "admin") {
       console.log("🚀 Initial data load triggered by authentication");
       loadData();
     }
-  }, [isAuthenticated]);
+  }, [authIsAuthenticated, authUser]);
 
   // Add effect to listen for user import events
   useEffect(() => {
@@ -587,11 +584,6 @@ const AdminSpace = () => {
     URL.revokeObjectURL(url);
   };
 
-  const handleLogin = () => {
-    setIsAuthenticated(true);
-    setShowLogin(false);
-  };
-
   // Helper function to fix encoding issues
   const fixEncoding = (text) => {
     if (!text || typeof text !== "string") return text;
@@ -656,57 +648,14 @@ const AdminSpace = () => {
   };
 
   // Check authentication and role
-  const { user: authUser, isAuthenticated: authIsAuthenticated } = useAuth();
-
-  React.useEffect(() => {
-    console.log("🔍 Admin space useEffect triggered:", {
-      authIsAuthenticated,
-      authUser: authUser
-        ? { email: authUser.email, role: authUser.role }
-        : null,
-    });
-
-    if (authIsAuthenticated && authUser) {
-      console.log("🔍 Admin space access check:", {
-        email: authUser.email,
-        role: authUser.role,
-        isAdmin: authUser.role === "admin",
-      });
-
-      // Force admin access for development admin user
-      if (
-        authUser.email === "admin@lecompasolfactif.com" ||
-        authUser.role === "admin"
-      ) {
-        setIsAuthenticated(true);
-        setShowLogin(false);
-        console.log("✅ Admin access granted for:", authUser.email);
-        return; // Important: return early to prevent further execution
-      } else {
-        console.log(
-          "❌ Access denied for user:",
-          authUser.email,
-          "Role:",
-          authUser.role,
-        );
-        alert(
-          `Accès non autorisé. Votre rôle actuel: ${authUser.role}. Seuls les administrateurs peuvent accéder à cet espace.`,
-        );
-        setTimeout(() => {
-          window.location.href = "/";
-        }, 100);
-        return;
-      }
-    } else if (!authIsAuthenticated) {
-      console.log("🔐 User not authenticated, showing login");
-      setIsAuthenticated(false);
-      setShowLogin(true);
-    }
-  }, [authIsAuthenticated, authUser]);
+  const {
+    user: authUser,
+    isAuthenticated: authIsAuthenticated,
+    signOut,
+  } = useAuth();
 
   const handleLogout = () => {
-    setIsAuthenticated(false);
-    setShowLogin(true);
+    signOut();
   };
 
   const toggleProductStatus = async (productId) => {
@@ -2609,23 +2558,19 @@ const AdminSpace = () => {
     input.click();
   };
 
-  // Show login dialog if not authenticated
-  if (!authIsAuthenticated || showLogin) {
+  // Show login dialog if not authenticated or not admin
+  if (!authIsAuthenticated || authUser?.role !== "admin") {
     return (
       <LoginDialog
-        open={showLogin}
-        onOpenChange={setShowLogin}
-        onSuccess={() => {
-          console.log("🔐 Login successful, checking user role...");
-          // The useEffect will handle the role check after login
-        }}
+        open={!authIsAuthenticated || authUser?.role !== "admin"}
+        onOpenChange={() => {}}
         hideRegistration={true}
       />
     );
   }
 
-  // Show loading while checking authentication or loading data
-  if ((authIsAuthenticated && authUser && !isAuthenticated) || loading) {
+  // Show loading while loading data
+  if (authIsAuthenticated && authUser?.role === "admin" && loading) {
     return (
       <div className="min-h-screen bg-[#FBF0E9] flex items-center justify-center">
         <div className="text-center">
@@ -2635,33 +2580,6 @@ const AdminSpace = () => {
               ? "Chargement des données..."
               : "Vérification des autorisations..."}
           </p>
-        </div>
-      </div>
-    );
-  }
-
-  // Block access if user is authenticated but not admin
-  if (
-    authIsAuthenticated &&
-    authUser &&
-    authUser.role !== "admin" &&
-    authUser.email !== "admin@lecompasolfactif.com"
-  ) {
-    return (
-      <div className="min-h-screen bg-[#FBF0E9] flex items-center justify-center">
-        <div className="text-center bg-white p-8 rounded-lg shadow-lg">
-          <h2 className="text-2xl font-playfair text-[#805050] mb-4">
-            Accès Refusé
-          </h2>
-          <p className="text-[#AD9C92] mb-6">
-            Seuls les administrateurs peuvent accéder à cet espace.
-          </p>
-          <button
-            onClick={() => (window.location.href = "/")}
-            className="bg-[#805050] hover:bg-[#704040] text-white px-6 py-2 rounded"
-          >
-            Retour à l'accueil
-          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- remove AdminSpace local auth state and use auth context directly
- show login dialog for unauthenticated or non-admin users
- add tests for admin login visibility

## Testing
- `npm install` (failed: 403 Forbidden)
- `npm run lint` (failed: ESLint configuration missing)
- `npm test` (failed: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3db7c2680832bb6654ea0c8a893b4