### PR TITLE
feat(admin): expose list users endpoint

### DIFF
--- a/api/admin/list-users.js
+++ b/api/admin/list-users.js
@@ -1,0 +1,87 @@
+import { createClient } from '@supabase/supabase-js';
+
+const {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  SUPABASE_SERVICE_ROLE_KEY
+} = process.env;
+
+export default async function handler(req, res) {
+  const origin = process.env.ALLOWED_ORIGIN || '*';
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  try {
+    const authHeader = req.headers.authorization || '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : null;
+
+    if (!token) {
+      res.status(401).json({ error: 'Missing bearer token' });
+      return;
+    }
+
+    const caller = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      global: {
+        headers: { Authorization: `Bearer ${token}` }
+      },
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    const {
+      data: { user },
+      error: userError
+    } = await caller.auth.getUser();
+    if (userError || !user) {
+      res.status(401).json({ error: 'Invalid token' });
+      return;
+    }
+
+    const { data: roleData, error: roleError } = await caller
+      .from('users')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    if (roleError) {
+      res.status(500).json({ error: roleError.message });
+      return;
+    }
+
+    if (!roleData || roleData.role !== 'admin') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+
+    const service = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false }
+    });
+
+    const { data, error } = await service
+      .from('users')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add secured endpoint to list users for admin role
- load admin users via fetch to new endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3de8d19c8832b8eb3194b00b3e693