### PR TITLE
Validate admin session and purge tokens on Supabase errors

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -59,7 +59,7 @@ import {
 } from "lucide-react";
 import PerfumeCatalog from "./catalog/PerfumeCatalog";
 import PerfumeDetail from "./catalog/PerfumeDetail";
-import { supabase } from "@/lib/supabaseClient";
+import { supabase, purgeLocalSupabaseTokens } from "@/lib/supabaseClient";
 
 const AdminSpace = () => {
   const {
@@ -597,46 +597,58 @@ const AdminSpace = () => {
 
   // Check authentication and role
   React.useEffect(() => {
-    console.log("🔍 Admin space useEffect triggered:", {
-      authIsAuthenticated,
-      authUser: authUser
-        ? { email: authUser.email, role: authUser.role }
-        : null,
-    });
-
-    if (authIsAuthenticated && authUser) {
-      console.log("🔍 Admin space access check:", {
-        email: authUser.email,
-        role: authUser.role,
-        isAdmin: authUser.role === "admin",
+    const check = async () => {
+      console.log("🔍 Admin space useEffect triggered:", {
+        authIsAuthenticated,
+        authUser: authUser
+          ? { email: authUser.email, role: authUser.role }
+          : null,
       });
 
-      // Force admin access for development admin user
-      if (
-        authUser.email === "admin@lecompasolfactif.com" ||
-        authUser.role === "admin"
-      ) {
-        setShowLogin(false);
-        console.log("✅ Admin access granted for:", authUser.email);
-        loadData();
-      } else {
-        console.log(
-          "❌ Access denied for user:",
-          authUser.email,
-          "Role:",
-          authUser.role,
-        );
-        alert(
-          `Accès non autorisé. Votre rôle actuel: ${authUser.role}. Seuls les administrateurs peuvent accéder à cet espace.`,
-        );
-        setTimeout(() => {
-          window.location.href = "/";
-        }, 100);
+      const { error } = await supabase.auth.getUser();
+      if (error) {
+        await supabase.auth.signOut();
+        purgeLocalSupabaseTokens();
+        setShowLogin(true);
+        return;
       }
-    } else if (!authIsAuthenticated) {
-      console.log("🔐 User not authenticated, showing login");
-      setShowLogin(true);
-    }
+
+      if (authIsAuthenticated && authUser) {
+        console.log("🔍 Admin space access check:", {
+          email: authUser.email,
+          role: authUser.role,
+          isAdmin: authUser.role === "admin",
+        });
+
+        // Force admin access for development admin user
+        if (
+          authUser.email === "admin@lecompasolfactif.com" ||
+          authUser.role === "admin"
+        ) {
+          setShowLogin(false);
+          console.log("✅ Admin access granted for:", authUser.email);
+          loadData();
+        } else {
+          console.log(
+            "❌ Access denied for user:",
+            authUser.email,
+            "Role:",
+            authUser.role,
+          );
+          alert(
+            `Accès non autorisé. Votre rôle actuel: ${authUser.role}. Seuls les administrateurs peuvent accéder à cet espace.`,
+          );
+          setTimeout(() => {
+            window.location.href = "/";
+          }, 100);
+        }
+      } else if (!authIsAuthenticated) {
+        console.log("🔐 User not authenticated, showing login");
+        setShowLogin(true);
+      }
+    };
+
+    check();
   }, [authIsAuthenticated, authUser]);
 
   const handleLogout = () => {


### PR DESCRIPTION
## Summary
- import purgeLocalSupabaseTokens helper
- verify Supabase session in admin useEffect and purge on error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5a74244832b8c251a8a3019512e