### PR TITLE
feat: add playfair and montserrat fonts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -71,6 +71,14 @@
       @apply border-border;
     }
     body {
-      @apply bg-background text-foreground;
+      @apply bg-background text-foreground font-montserrat;
+    }
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      @apply font-playfair;
     }
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './index.css' // supprime cette ligne si le fichier n'existe pas
+import '@fontsource/playfair-display/400.css'
+import '@fontsource/playfair-display/700.css'
+import '@fontsource/montserrat/400.css'
+import '@fontsource/montserrat/700.css'
 
 import { ensureValidSession } from './lib/supabaseClient'
 ensureValidSession().catch(() => {})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,6 +52,10 @@ module.exports = {
           foreground: "hsl(var(--card-foreground))",
         },
       },
+      fontFamily: {
+        playfair: ['"Playfair Display"', "serif"],
+        montserrat: ["Montserrat", "sans-serif"],
+      },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
## Summary
- extend Tailwind with Playfair Display and Montserrat fonts
- import fonts globally and apply default typography

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a588b34d60832b99ecb51959d86229