### PR TITLE
feat: move font imports to global stylesheet

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+@import '@fontsource/playfair-display/400.css';
+@import '@fontsource/playfair-display/700.css';
+@import '@fontsource/montserrat/400.css';
+@import '@fontsource/montserrat/700.css';
+
 @tailwind base;
   @tailwind components;
   @tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,6 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './index.css' // supprime cette ligne si le fichier n'existe pas
-import '@fontsource/playfair-display/400.css'
-import '@fontsource/playfair-display/700.css'
-import '@fontsource/montserrat/400.css'
-import '@fontsource/montserrat/700.css'
 
 import { ensureValidSession } from './lib/supabaseClient'
 ensureValidSession().catch(() => {})


### PR DESCRIPTION
## Summary
- add Playfair Display and Montserrat font imports to global index.css
- clean up main entry by removing individual font imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a589cefb88832b892bad0fa6902844