### PR TITLE
chore: unify advisor path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { useRoutes, Routes, Route } from "react-router-dom";
-import Home from "./components/home";
+import HomePage from "./pages/HomePage";
 import ClientSpace from "./components/ClientSpace";
 import ConseillerSpace from "./components/ConseillerSpace";
 import AdminSpace from "./components/AdminSpace";
@@ -19,9 +19,9 @@ function App() {
           <Suspense fallback={<p>Loading...</p>}>
             <>
               <Routes>
-                <Route path="/" element={<Home />} />
+                <Route path="/" element={<HomePage />} />
                 <Route path="/client" element={<ClientSpace />} />
-                <Route path="/conseillere" element={<ConseillerSpace />} />
+                <Route path="/advisor" element={<ConseillerSpace />} />
                 <Route path="/admin" element={<AdminSpace />} />
               </Routes>
               {tempoRoutes}

--- a/src/components/ClientSpace.tsx
+++ b/src/components/ClientSpace.tsx
@@ -172,7 +172,7 @@ const ClientSpace = () => {
       alert(
         "Accès non autorisé. Les conseillères doivent utiliser leur espace dédié.",
       );
-      window.location.href = "/conseillere";
+      window.location.href = "/advisor";
     }
   }, [isAuthenticated, user]);
 

--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -3,9 +3,10 @@ import { motion } from "framer-motion";
 
 interface HomeLayoutProps {
   children?: React.ReactNode;
+  advisorPath?: string;
 }
 
-const HomeLayout = ({ children = null }: HomeLayoutProps) => {
+const HomeLayout = ({ children = null, advisorPath = "/advisor" }: HomeLayoutProps) => {
   return (
     <div className="min-h-screen flex flex-col items-center justify-start py-10 px-4 bg-[#FBF0E9]">
       <motion.div
@@ -55,7 +56,7 @@ const HomeLayout = ({ children = null }: HomeLayoutProps) => {
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             className="bg-[#D4C2A1] hover:bg-[#C4B291] text-[#805050] font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
-            onClick={() => (window.location.href = "/conseillere")}
+            onClick={() => (window.location.href = advisorPath)}
           >
             <div className="w-10 h-10 bg-white bg-opacity-30 rounded-full flex items-center justify-center">
               <span className="text-xl">💼</span>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { motion } from "framer-motion";
-import HomeLayout from "./HomeLayout";
+import HomeLayout from "../components/HomeLayout";
 
-const Home = () => {
+const HomePage = () => {
   return (
     <div className="min-h-screen bg-[#FBF0E9] flex flex-col items-center justify-center p-4">
       <motion.div
@@ -11,10 +11,10 @@ const Home = () => {
         transition={{ duration: 0.8 }}
         className="w-full max-w-4xl h-[600px]"
       >
-        <HomeLayout />
+        <HomeLayout advisorPath="/advisor" />
       </motion.div>
     </div>
   );
 };
 
-export default Home;
+export default HomePage;


### PR DESCRIPTION
## Summary
- use `/advisor` consistently for the counselor route
- rename Home component to HomePage and wire up new route
- adjust client redirect and layout link to point to `/advisor`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a58b312d18832b8f90e86d217df0f9