### PR TITLE
feat: add named colors and use in homepage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ import HomeLayout from "../components/HomeLayout";
 
 const HomePage = () => {
   return (
-    <div className="min-h-screen bg-[#FBF0E9] flex flex-col items-center justify-center p-4">
+    <div className="min-h-screen bg-cream flex flex-col items-center justify-center p-4">
       <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,10 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        advisor: "#D4C2A1",
+        admin: "#805050",
+        client: "#CE8F8A",
+        cream: "#FBF0E9",
       },
       fontFamily: {
         playfair: ['"Playfair Display"', "serif"],


### PR DESCRIPTION
## Summary
- define advisor, admin, client, and cream colors in Tailwind config
- use new `cream` utility instead of hard-coded hex in HomePage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a58cd0f6b4832ba090178343011c60