### PR TITLE
Use React Router navigation in home layout

### DIFF
--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -8,7 +8,7 @@ interface HomeLayoutProps {
 }
 
 const HomeLayout = ({ children = null, advisorPath = "/advisor" }: HomeLayoutProps) => {
-  const navigate = useNavigate();
+  const navigate = useNavigate(); // use client-side navigation
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-start py-10 px-4 bg-[#FBF0E9]">


### PR DESCRIPTION
## Summary
- clarify that `HomeLayout` uses React Router's `useNavigate` for SPA-style navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5965749b4832ba717f0d28b74fde8