### PR TITLE
Fix admin and advisor navigation from home page

### DIFF
--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 interface HomeLayoutProps {
   children?: React.ReactNode;
@@ -8,7 +8,7 @@ interface HomeLayoutProps {
 }
 
 const HomeLayout = ({ children = null, advisorPath = "/advisor" }: HomeLayoutProps) => {
-  const navigate = useNavigate(); // use client-side navigation
+  const MotionLink = motion(Link);
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-start py-10 px-4 bg-[#FBF0E9]">
@@ -41,46 +41,46 @@ const HomeLayout = ({ children = null, advisorPath = "/advisor" }: HomeLayoutPro
       >
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {/* Client Button */}
-          <motion.button
+          <MotionLink
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
+            to="/client"
             className="bg-[#CE8F8A] hover:bg-[#B87B76] text-white font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
-            onClick={() => navigate("/client")}
           >
             <div className="w-10 h-10 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
               <span className="text-xl">👤</span>
             </div>
             <span className="text-base">Espace Client</span>
             <span className="text-xs opacity-90">Découvrir nos parfums</span>
-          </motion.button>
+          </MotionLink>
 
           {/* Conseillère Button */}
-          <motion.button
+          <MotionLink
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
+            to={advisorPath}
             className="bg-[#D4C2A1] hover:bg-[#C4B291] text-[#805050] font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
-            onClick={() => navigate(advisorPath)}
           >
             <div className="w-10 h-10 bg-white bg-opacity-30 rounded-full flex items-center justify-center">
               <span className="text-xl">💼</span>
             </div>
             <span className="text-base">Espace Conseillère</span>
             <span className="text-xs opacity-90">Gérer les conseils</span>
-          </motion.button>
+          </MotionLink>
 
           {/* Admin Button */}
-          <motion.button
+          <MotionLink
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
+            to="/admin"
             className="bg-[#805050] hover:bg-[#704040] text-white font-montserrat font-semibold py-6 px-4 rounded-lg shadow-lg transition-all duration-300 flex flex-col items-center space-y-2"
-            onClick={() => navigate("/admin")}
           >
             <div className="w-10 h-10 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
               <span className="text-xl">⚙️</span>
             </div>
             <span className="text-base">Espace Admin</span>
             <span className="text-xs opacity-90">Administration</span>
-          </motion.button>
+          </MotionLink>
         </div>
       </motion.div>
       {/* Content area */}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,16 +1,15 @@
 
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useRef, useEffect, useLayoutEffect, useState } from "react";
 import { motion, useTransform, useSpring, useMotionValue } from "framer-motion";
 import bottle from "/images/bouteille1.webp";
 
 const HomePage = () => {
-  const navigate = useNavigate();
   const scrollY = useMotionValue(0);
   const smoothScroll = useSpring(scrollY, { stiffness: 100, damping: 15 });
 
   const bottleRef = useRef<HTMLImageElement>(null);
-  const clientButtonRef = useRef<HTMLButtonElement>(null);
+  const clientButtonRef = useRef<HTMLAnchorElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [dropDistance, setDropDistance] = useState(0);
   const [scrollRange, setScrollRange] = useState(1);
@@ -80,18 +79,12 @@ const HomePage = () => {
         playsInline
       />
       <nav className="absolute top-4 left-0 w-full flex justify-between px-4 text-xs font-montserrat z-10">
-        <button
-          onClick={() => navigate("/advisor")}
-          className="px-3 py-2 rounded bg-advisor text-admin"
-        >
+        <Link to="/advisor" className="px-3 py-2 rounded bg-advisor text-admin">
           Espace Conseillère
-        </button>
-        <button
-          onClick={() => navigate("/admin")}
-          className="px-3 py-2 rounded bg-admin text-cream"
-        >
+        </Link>
+        <Link to="/admin" className="px-3 py-2 rounded bg-admin text-cream">
           Espace Admin
-        </button>
+        </Link>
       </nav>
 
       <div className="pt-24 flex flex-col items-center relative z-10">
@@ -114,13 +107,13 @@ const HomePage = () => {
       </div>
 
       <div className="absolute bottom-10 left-1/2 -translate-x-1/2 z-10">
-        <button
+        <Link
           ref={clientButtonRef}
-          onClick={() => navigate("/client")}
+          to="/client"
           className="px-5 py-3 rounded bg-client text-cream font-montserrat text-sm"
         >
           Espace Client
-        </button>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -78,7 +78,7 @@ const HomePage = () => {
         muted
         playsInline
       />
-      <nav className="absolute top-4 left-0 w-full flex justify-between px-4 text-xs font-montserrat z-10">
+      <nav className="absolute top-4 left-0 w-full flex justify-between px-4 text-xs font-montserrat z-50">
         <Link to="/advisor" className="px-3 py-2 rounded bg-advisor text-admin">
           Espace Conseillère
         </Link>
@@ -87,7 +87,7 @@ const HomePage = () => {
         </Link>
       </nav>
 
-      <div className="pt-24 flex flex-col items-center relative z-10">
+      <div className="pointer-events-none pt-24 flex flex-col items-center relative z-10">
         <h1 className="text-3xl text-cream mb-8 font-playfair text-center">
           Le Compas Olfactif
         </h1>


### PR DESCRIPTION
## Summary
- Use React Router links instead of buttons on the home page and layout
- Enable direct navigation to advisor, admin, and client spaces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab4a49e164832b830835d549ce8bb7