### PR TITLE
Refactor admin auth to rely on context

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -62,13 +62,18 @@ import PerfumeDetail from "./catalog/PerfumeDetail";
 import { supabase } from "../lib/supabaseClient";
 
 const AdminSpace = () => {
-  const { register } = useAuth();
+  const {
+    user: authUser,
+    isAuthenticated: authIsAuthenticated,
+    login,
+    signOut,
+    loading: authLoading,
+  } = useAuth();
   const { toast } = useToast();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedProduct, setSelectedProduct] = useState(null);
   const [dateFilter, setDateFilter] = useState({ start: "", end: "" });
-  const [showLogin, setShowLogin] = useState(true);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [showLogin, setShowLogin] = useState(!authIsAuthenticated);
   const [showNewProduct, setShowNewProduct] = useState(false);
   const [noteTete, setNoteTete] = useState("");
   const [noteCoeur, setNoteCoeur] = useState("");
@@ -97,6 +102,15 @@ const AdminSpace = () => {
     role: "client",
     password: "",
   });
+
+  // If offline admin flag is present, hide the login modal on mount
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      if (localStorage.getItem("offlineAdmin") === "true") {
+        setShowLogin(false);
+      }
+    }
+  }, []);
 
   // Preview states
   const [previewFile, setPreviewFile] = useState(null);
@@ -422,11 +436,11 @@ const AdminSpace = () => {
   };
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (authIsAuthenticated) {
       console.log("🚀 Initial data load triggered by authentication");
       loadData();
     }
-  }, [isAuthenticated]);
+  }, [authIsAuthenticated]);
 
   // Add effect to listen for user import events
   useEffect(() => {
@@ -656,10 +670,8 @@ const AdminSpace = () => {
   };
 
   // Check authentication and role
-  const { user: authUser, isAuthenticated: authIsAuthenticated } = useAuth();
-
-  React.useEffect(() => {
-    console.log("🔍 Admin space useEffect triggered:", {
+  useEffect(() => {
+    console.log("🔍 Admin space auth change:", {
       authIsAuthenticated,
       authUser: authUser
         ? { email: authUser.email, role: authUser.role }
@@ -667,21 +679,12 @@ const AdminSpace = () => {
     });
 
     if (authIsAuthenticated && authUser) {
-      console.log("🔍 Admin space access check:", {
-        email: authUser.email,
-        role: authUser.role,
-        isAdmin: authUser.role === "admin",
-      });
-
-      // Force admin access for development admin user
       if (
         authUser.email === "admin@lecompasolfactif.com" ||
         authUser.role === "admin"
       ) {
-        setIsAuthenticated(true);
         setShowLogin(false);
         console.log("✅ Admin access granted for:", authUser.email);
-        return; // Important: return early to prevent further execution
       } else {
         console.log(
           "❌ Access denied for user:",
@@ -692,20 +695,20 @@ const AdminSpace = () => {
         alert(
           `Accès non autorisé. Votre rôle actuel: ${authUser.role}. Seuls les administrateurs peuvent accéder à cet espace.`,
         );
+        setShowLogin(true);
+        signOut();
         setTimeout(() => {
           window.location.href = "/";
         }, 100);
-        return;
       }
-    } else if (!authIsAuthenticated) {
+    } else {
       console.log("🔐 User not authenticated, showing login");
-      setIsAuthenticated(false);
       setShowLogin(true);
     }
-  }, [authIsAuthenticated, authUser]);
+  }, [authIsAuthenticated, authUser, signOut]);
 
   const handleLogout = () => {
-    setIsAuthenticated(false);
+    signOut();
     setShowLogin(true);
   };
 
@@ -2617,15 +2620,16 @@ const AdminSpace = () => {
         onOpenChange={setShowLogin}
         onSuccess={() => {
           console.log("🔐 Login successful, checking user role...");
-          // The useEffect will handle the role check after login
+          // The auth context effect will handle the role check after login
         }}
         hideRegistration={true}
+        login={login}
       />
     );
   }
 
   // Show loading while checking authentication or loading data
-  if ((authIsAuthenticated && authUser && !isAuthenticated) || loading) {
+  if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-[#FBF0E9] flex items-center justify-center">
         <div className="text-center">

--- a/src/components/ClientSpace.tsx
+++ b/src/components/ClientSpace.tsx
@@ -164,7 +164,7 @@ const ClientSpace = () => {
   const [editedUser, setEditedUser] = useState<any>(null);
   const { getTotalItems } = useCart();
   const { favorites, removeFromFavorites } = useFavorites();
-  const { isAuthenticated, user, updateUser, signOut } = useAuth();
+  const { isAuthenticated, user, updateUser, signOut, login } = useAuth();
 
   // Check role-based access - only allow clients and admins
   React.useEffect(() => {
@@ -798,7 +798,7 @@ const ClientSpace = () => {
       </div>
 
       <CartDialog open={showCart} onOpenChange={setShowCart} />
-      <LoginDialog open={showLogin} onOpenChange={setShowLogin} />
+      <LoginDialog open={showLogin} onOpenChange={setShowLogin} login={login} />
     </div>
   );
 };

--- a/src/components/ConseillerSpace.tsx
+++ b/src/components/ConseillerSpace.tsx
@@ -35,6 +35,7 @@ const ConseillerSpace = () => {
   const authContext = useAuth();
   const user = authContext?.user;
   const isAuthenticated = authContext?.isAuthenticated || false;
+  const login = authContext?.login;
 
   // Component state
   const [showLogin, setShowLogin] = useState(false);
@@ -359,6 +360,7 @@ const ConseillerSpace = () => {
             setShowLogin(false);
           }}
           hideRegistration={true}
+          login={login}
         />
       </div>
     );

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -11,7 +11,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { handleSignIn } from "@/features/auth/signIn";
 import { handleSignUp } from "@/features/auth/signUp";
 
 interface LoginDialogProps {
@@ -19,6 +18,7 @@ interface LoginDialogProps {
   onOpenChange: (open: boolean) => void;
   onSuccess?: () => void;
   hideRegistration?: boolean;
+  login: (email: string, password: string) => Promise<any>;
 }
 
 const LoginDialog: React.FC<LoginDialogProps> = ({
@@ -26,6 +26,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({
   onOpenChange,
   onSuccess,
   hideRegistration = false,
+  login,
 }) => {
   /* -------- Connexion -------- */
   const [loginEmail, setLoginEmail] = useState("");
@@ -39,7 +40,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({
     setLoginBusy(true);
     setLoginMsg(null);
 
-    const res = await handleSignIn(loginEmail.trim(), loginPassword);
+    const res = await login(loginEmail.trim(), loginPassword);
 
     setLoginBusy(false);
     if (!res.ok) {

--- a/src/components/cart/CartDialog.tsx
+++ b/src/components/cart/CartDialog.tsx
@@ -25,7 +25,7 @@ interface CartDialogProps {
 const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
   const { items, removeFromCart, updateQuantity, getTotalPrice, clearCart } =
     useCart();
-  const { isAuthenticated, user, updateUser } = useAuth() as any;
+  const { isAuthenticated, user, updateUser, login } = useAuth() as any;
   const [showLogin, setShowLogin] = useState(false);
   const [orderComplete, setOrderComplete] = useState(false);
   const [showCheckout, setShowCheckout] = useState(false);
@@ -391,6 +391,7 @@ const CartDialog: React.FC<CartDialogProps> = ({ open, onOpenChange }) => {
         open={showLogin}
         onOpenChange={setShowLogin}
         onSuccess={handleLoginSuccess}
+        login={login}
       />
 
       {/* Checkout Preview Dialog */}


### PR DESCRIPTION
## Summary
- Use AuthContext for admin authentication and offline mode detection
- Pass login function to LoginDialog and forward from consumers
- Close login modal and load data when auth state changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac155bfeb8832ba16abaa6dcf422cb