### PR TITLE
Normalize role comparisons and improve login diagnostics

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import type { Session, User as SupabaseUser } from '@supabase/supabase-js';
 import { handleSignIn } from '@/features/auth/signIn';
 import { handleSignUp } from '@/features/auth/signUp';
 import { supabase } from '@/lib/supabaseClient';
+import { normalizeRole } from '@/lib/utils';
 
 interface User extends SupabaseUser {
   role?: string;
@@ -65,7 +66,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .single();
       role = data?.role ?? undefined;
     }
-    return { ...u, role: role ?? 'client' } as User;
+    const normalized = normalizeRole(role) || 'client'
+    return { ...u, role: normalized } as User;
   };
 
   useEffect(() => {

--- a/src/features/auth/signIn.ts
+++ b/src/features/auth/signIn.ts
@@ -49,11 +49,13 @@ export async function handleSignIn(email: string, password: string) {
       .or(`id.eq.${user.id},uid.eq.${user.id}`)
       .maybeSingle();
     if (selErr) {
-      throw new Error(selErr.message);
+      console.error('Erreur lors de la récupération du profil:', selErr);
+      return { ok: false, step: 'profile', error: selErr.message };
     }
 
     // Création du profil s'il n'existe pas encore
     if (!profile) {
+      console.warn(`Profil introuvable pour l'utilisateur ${user.id}, création...`);
       const { error: insertErr } = await supabase.from('users').insert({
         id: user.id,
         uid: user.id,
@@ -69,7 +71,8 @@ export async function handleSignIn(email: string, password: string) {
         nom: '',
       });
       if (insertErr) {
-        throw new Error(insertErr.message);
+        console.error('Erreur lors de la création du profil:', insertErr);
+        return { ok: false, step: 'profile', error: insertErr.message };
       }
     } else {
       // Mise à jour éventuelle du rôle ou de l'email si manquants
@@ -84,7 +87,8 @@ export async function handleSignIn(email: string, password: string) {
           .update(updates)
           .or(`id.eq.${user.id},uid.eq.${user.id}`);
         if (updErr) {
-          throw new Error(updErr.message);
+          console.error('Erreur lors de la mise à jour du profil:', updErr);
+          return { ok: false, step: 'profile', error: updErr.message };
         }
       }
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function normalizeRole(role?: string | null) {
+  if (!role) return ""
+  return role
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+}

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/lib/supabaseClient";
 import { logger } from "@/lib/logger";
+import { normalizeRole } from "@/lib/utils";
 
 export interface User {
   id: string;
@@ -113,7 +114,7 @@ export async function login(
       whatsapp: userRecord.whatsapp || undefined,
       dateNaissance: userRecord.date_naissance || undefined,
       adresse: userRecord.adresse || undefined,
-      role: userRecord.role as "client" | "conseillere" | "admin",
+      role: normalizeRole(userRecord.role) as "client" | "conseillere" | "admin",
       codeClient: userRecord.code_client || undefined,
     };
   } catch (err) {
@@ -135,8 +136,9 @@ export async function register(
       role = "client",
       codeClient: providedCodeClient,
     } = userData;
+    const normalizedRole = normalizeRole(role) as "client" | "conseillere" | "admin";
     const rolePrefix =
-      role === "conseillere" ? "CNS" : role === "admin" ? "ADM" : "C";
+      normalizedRole === "conseillere" ? "CNS" : normalizedRole === "admin" ? "ADM" : "C";
     const codeClient =
       providedCodeClient || `${rolePrefix}${Date.now().toString().slice(-3)}`;
 
@@ -162,7 +164,7 @@ export async function register(
         whatsapp: userData.whatsapp || null,
         date_naissance: userData.dateNaissance || null,
         adresse: userData.adresse || null,
-        role,
+        role: normalizedRole,
         code_client: codeClient,
       })
       .select()
@@ -183,7 +185,7 @@ export async function register(
       whatsapp: userData.whatsapp,
       dateNaissance: userData.dateNaissance,
       adresse: userData.adresse,
-      role,
+      role: normalizedRole,
       codeClient: insertedUser.code_client || codeClient,
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- add `normalizeRole` helper to strip accents and lowercase roles
- use normalized roles in auth context and service
- add profile fetch diagnostics in sign-in flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'codeArticle' does not exist on type '{}', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1fdb8b50832bba328b6794b066a5