### PR TITLE
Remove offline admin fallback

### DIFF
--- a/src/components/AdminSpace.tsx
+++ b/src/components/AdminSpace.tsx
@@ -103,15 +103,6 @@ const AdminSpace = () => {
     password: "",
   });
 
-  // If offline admin flag is present, hide the login modal on mount
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      if (localStorage.getItem("offlineAdmin") === "true") {
-        setShowLogin(false);
-      }
-    }
-  }, []);
-
   // Preview states
   const [previewFile, setPreviewFile] = useState(null);
   const [previewData, setPreviewData] = useState([]);


### PR DESCRIPTION
## Summary
- drop offline admin mode and associated localStorage flag
- simplify authentication context to rely solely on Supabase sessions
- stop hiding admin login dialog based on offline flag

## Testing
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac40cddae0832b9a25f65a6b7a6e2e